### PR TITLE
feat: BE-02 Entity + Repository (account, auth, interest)

### DIFF
--- a/src/main/kotlin/com/chat/chingudachi/ChinguDachiApplication.kt
+++ b/src/main/kotlin/com/chat/chingudachi/ChinguDachiApplication.kt
@@ -3,10 +3,12 @@ package com.chat.chingudachi
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import java.util.TimeZone
 
 @EnableConfigurationProperties
 @SpringBootApplication
+@EnableJpaAuditing
 class ChinguDachiApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
@@ -3,6 +3,8 @@ package com.chat.chingudachi.domain.account
 import com.chat.chingudachi.domain.common.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -17,11 +19,13 @@ class Account(
     @Column(name = "account_id")
     val id: Long = 0,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "account_type", nullable = false, length = 10)
-    var accountType: String,
+    var accountType: AccountType,
 
-    @Column(name = "account_status", nullable = false, length = 10)
-    var accountStatus: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_status", nullable = false, length = 20)
+    var accountStatus: AccountStatus,
 
     @Column(length = 255)
     var email: String? = null,
@@ -32,11 +36,13 @@ class Account(
     @Column(name = "birth_date")
     var birthDate: LocalDate? = null,
 
+    @Enumerated(EnumType.STRING)
     @Column(length = 20)
-    var nation: String? = null,
+    var nation: Nation? = null,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "native_language", length = 2)
-    var nativeLanguage: String? = null,
+    var nativeLanguage: NativeLanguage? = null,
 
     @Column(length = 20)
     var city: String? = null,

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
@@ -1,0 +1,52 @@
+package com.chat.chingudachi.domain.account
+
+import com.chat.chingudachi.domain.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.time.LocalDate
+
+@Entity
+@Table(name = "account")
+class Account(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_id")
+    val id: Long = 0,
+
+    @Column(name = "account_type", nullable = false, length = 10)
+    var accountType: String,
+
+    @Column(name = "account_status", nullable = false, length = 10)
+    var accountStatus: String,
+
+    @Column(length = 255)
+    var email: String? = null,
+
+    @Column(length = 20)
+    var nickname: String? = null,
+
+    @Column(name = "birth_date")
+    var birthDate: LocalDate? = null,
+
+    @Column(length = 20)
+    var nation: String? = null,
+
+    @Column(name = "native_language", length = 2)
+    var nativeLanguage: String? = null,
+
+    @Column(length = 20)
+    var city: String? = null,
+
+    @Column(name = "profile_image_url", length = 255)
+    var profileImageUrl: String? = null,
+
+    @Column(length = 50)
+    var bio: String? = null,
+
+    @Column(name = "deleted_at")
+    var deletedAt: Instant? = null,
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/AccountCredential.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/AccountCredential.kt
@@ -3,6 +3,8 @@ package com.chat.chingudachi.domain.account
 import com.chat.chingudachi.domain.common.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -10,10 +12,19 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(name = "account_credentials")
-class AccountCredentials(
+@Table(
+    name = "account_credentials",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_account_credentials_account_type",
+            columnNames = ["account_id", "credential_type"],
+        ),
+    ],
+)
+class AccountCredential(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "account_credentials_id")
     val id: Long = 0,
@@ -22,8 +33,9 @@ class AccountCredentials(
     @JoinColumn(name = "account_id", nullable = false)
     val account: Account,
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "credential_type", nullable = false, length = 20)
-    val credentialType: String,
+    val credentialType: CredentialType,
 
     @Column(name = "oauth_key", length = 255)
     val oauthKey: String? = null,

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/AccountCredentials.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/AccountCredentials.kt
@@ -1,0 +1,30 @@
+package com.chat.chingudachi.domain.account
+
+import com.chat.chingudachi.domain.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "account_credentials")
+class AccountCredentials(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_credentials_id")
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: Account,
+
+    @Column(name = "credential_type", nullable = false, length = 20)
+    val credentialType: String,
+
+    @Column(name = "oauth_key", length = 255)
+    val oauthKey: String? = null,
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/AccountStatus.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/AccountStatus.kt
@@ -1,0 +1,9 @@
+package com.chat.chingudachi.domain.account
+
+enum class AccountStatus {
+    NOT_CONSENT,
+    NOT_ENOUGH_DETAIL,
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/AccountTermsAgreement.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/AccountTermsAgreement.kt
@@ -1,0 +1,33 @@
+package com.chat.chingudachi.domain.account
+
+import com.chat.chingudachi.domain.common.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "account_terms_agreement")
+class AccountTermsAgreement(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_terms_agreement_id")
+    val id: Long = 0,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: Account,
+
+    @Column(name = "is_terms_of_service_agree", nullable = false)
+    val isTermsOfServiceAgree: Boolean,
+
+    @Column(name = "is_privacy_policy_agree", nullable = false)
+    val isPrivacyPolicyAgree: Boolean,
+
+    @Column(name = "is_marketing_agree", nullable = false)
+    val isMarketingAgree: Boolean,
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/AccountType.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/AccountType.kt
@@ -1,0 +1,5 @@
+package com.chat.chingudachi.domain.account
+
+enum class AccountType {
+    SOCIAL,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/CredentialType.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/CredentialType.kt
@@ -1,0 +1,5 @@
+package com.chat.chingudachi.domain.account
+
+enum class CredentialType {
+    GOOGLE,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Nation.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Nation.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.domain.account
+
+enum class Nation {
+    KR,
+    JP,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/NativeLanguage.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/NativeLanguage.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.domain.account
+
+enum class NativeLanguage {
+    KO,
+    JA,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
@@ -1,0 +1,34 @@
+package com.chat.chingudachi.domain.auth
+
+import com.chat.chingudachi.domain.account.Account
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "auth_token")
+class AuthToken(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "auth_token_id")
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: Account,
+
+    @Column(name = "refresh_token", nullable = false, length = 500)
+    val refreshToken: String,
+
+    @Column(name = "expires_at", nullable = false)
+    val expiresAt: Instant,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now(),
+)

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
@@ -1,6 +1,7 @@
 package com.chat.chingudachi.domain.auth
 
 import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.common.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
@@ -28,7 +29,4 @@ class AuthToken(
 
     @Column(name = "expires_at", nullable = false)
     val expiresAt: Instant,
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    val createdAt: Instant = Instant.now(),
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/BaseTimeEntity.kt
@@ -13,9 +13,9 @@ import java.time.Instant
 abstract class BaseTimeEntity {
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    lateinit var createdAt: Instant
+    var createdAt: Instant = Instant.MIN
 
     @LastModifiedDate
     @Column(nullable = false)
-    lateinit var updatedAt: Instant
+    var updatedAt: Instant = Instant.MIN
 }

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/BaseTimeEntity.kt
@@ -1,0 +1,21 @@
+package com.chat.chingudachi.domain.common
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    lateinit var createdAt: Instant
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    lateinit var updatedAt: Instant
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/interest/InterestTag.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/interest/InterestTag.kt
@@ -1,0 +1,28 @@
+package com.chat.chingudachi.domain.interest
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "interest_tag")
+class InterestTag(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interest_tag_id")
+    val id: Long = 0,
+
+    @Column(name = "tag_key", nullable = false, unique = true, length = 20)
+    val tagKey: String,
+
+    @Column(name = "label_ko", nullable = false, length = 20)
+    val labelKo: String,
+
+    @Column(name = "label_ja", nullable = false, length = 20)
+    val labelJa: String,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int,
+)

--- a/src/main/kotlin/com/chat/chingudachi/domain/interest/InterestTag.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/interest/InterestTag.kt
@@ -1,5 +1,6 @@
 package com.chat.chingudachi.domain.interest
 
+import com.chat.chingudachi.domain.common.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
@@ -25,4 +26,4 @@ class InterestTag(
 
     @Column(name = "display_order", nullable = false)
     val displayOrder: Int,
-)
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/chat/chingudachi/domain/interest/UserInterest.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/interest/UserInterest.kt
@@ -10,9 +10,18 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(name = "user_interest")
+@Table(
+    name = "user_interest",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_user_interest_account_tag",
+            columnNames = ["account_id", "interest_tag_id"],
+        ),
+    ],
+)
 class UserInterest(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_interest_id")

--- a/src/main/kotlin/com/chat/chingudachi/domain/interest/UserInterest.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/interest/UserInterest.kt
@@ -1,0 +1,28 @@
+package com.chat.chingudachi.domain.interest
+
+import com.chat.chingudachi.domain.account.Account
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "user_interest")
+class UserInterest(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_interest_id")
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: Account,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "interest_tag_id", nullable = false)
+    val interestTag: InterestTag,
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountRepository.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.infrastructure.persistence.account
+
+import com.chat.chingudachi.domain.account.Account
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccountRepository : JpaRepository<Account, Long>

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.infrastructure.persistence.auth
+
+import com.chat.chingudachi.domain.auth.AuthToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AuthTokenRepository : JpaRepository<AuthToken, Long>

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagRepository.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.infrastructure.persistence.interest
+
+import com.chat.chingudachi.domain.interest.InterestTag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface InterestTagRepository : JpaRepository<InterestTag, Long>

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestRepository.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.infrastructure.persistence.interest
+
+import com.chat.chingudachi.domain.interest.UserInterest
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserInterestRepository : JpaRepository<UserInterest, Long>


### PR DESCRIPTION
## Summary
- 6개 JPA Entity + 4개 Spring Data Repository 생성
- BaseTimeEntity 추가 (JPA Auditing)
- `ddl-auto: validate`로 DB 스키마 정합성 검증

## Changes
- `domain/common/BaseTimeEntity` — createdAt/updatedAt 자동 감사
- `domain/account/` — Account(AR), AccountCredentials, AccountTermsAgreement
- `domain/auth/AuthToken` — JWT Refresh Token
- `domain/interest/` — InterestTag(시드 15개), UserInterest(M:N 매핑)
- `infrastructure/persistence/` — AccountRepository, AuthTokenRepository, InterestTagRepository, UserInterestRepository
- `ChinguDachiApplication`에 `@EnableJpaAuditing` 추가

## Notes
- Entity는 domain/ 패키지에 JPA 어노테이션과 함께 배치 (MVP 실용주의)
- Repository는 기본 JpaRepository 인터페이스만 (커스텀 쿼리는 피처 구현 시 추가)
- 모든 연관관계 fetch = LAZY, 역방향 컬렉션 미선언

Closes #3