### PR TITLE
refactor: native_language → translate_language 언어 설정 재설계

### DIFF
--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
@@ -34,8 +34,8 @@ class Account(
     @Column(length = 20)
     var nation: Nation? = null,
     @Enumerated(EnumType.STRING)
-    @Column(name = "native_language", length = 2)
-    var nativeLanguage: NativeLanguage? = null,
+    @Column(name = "translate_language", length = 2)
+    var translateLanguage: TranslateLanguage? = null,
     @Column(length = 20)
     var city: String? = null,
     @Column(name = "profile_image_url", length = 255)
@@ -49,7 +49,7 @@ class Account(
         nickname != null &&
             birthDate != null &&
             nation != null &&
-            nativeLanguage != null
+            translateLanguage != null
 }
 
 @JvmInline
@@ -79,14 +79,14 @@ enum class Nation {
     KR,
     JP, ;
 
-    fun toNativeLanguage(): NativeLanguage =
+    fun toTranslateLanguage(): TranslateLanguage =
         when (this) {
-            KR -> NativeLanguage.KO
-            JP -> NativeLanguage.JA
+            KR -> TranslateLanguage.JA
+            JP -> TranslateLanguage.KO
         }
 }
 
-enum class NativeLanguage {
+enum class TranslateLanguage {
     KO,
     JA,
 }

--- a/src/test/kotlin/com/chat/chingudachi/domain/account/AccountTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/domain/account/AccountTest.kt
@@ -15,13 +15,13 @@ class AccountTest : DescribeSpec() {
                             nickname = Nickname("test"),
                             birthDate = LocalDate.now(),
                             nation = Nation.KR,
-                            nativeLanguage = Nation.KR.toNativeLanguage(),
+                            translateLanguage = Nation.KR.toTranslateLanguage(),
                         )
 
                     account.isOnboardingComplete() shouldBe true
                 }
 
-                it("nativeLanguage가 없으면 완료되지 않는다.") {
+                it("translateLanguage가 없으면 완료되지 않는다.") {
                     val account =
                         AccountFixture.create(
                             nickname = Nickname("test"),
@@ -37,7 +37,7 @@ class AccountTest : DescribeSpec() {
                         AccountFixture.create(
                             birthDate = LocalDate.now(),
                             nation = Nation.KR,
-                            nativeLanguage = Nation.KR.toNativeLanguage(),
+                            translateLanguage = Nation.KR.toTranslateLanguage(),
                         )
 
                     account.isOnboardingComplete() shouldBe false
@@ -48,7 +48,7 @@ class AccountTest : DescribeSpec() {
                         AccountFixture.create(
                             nickname = Nickname("test"),
                             nation = Nation.KR,
-                            nativeLanguage = Nation.KR.toNativeLanguage(),
+                            translateLanguage = Nation.KR.toTranslateLanguage(),
                         )
 
                     account.isOnboardingComplete() shouldBe false
@@ -59,7 +59,7 @@ class AccountTest : DescribeSpec() {
                         AccountFixture.create(
                             nickname = Nickname("test"),
                             birthDate = LocalDate.now(),
-                            nativeLanguage = Nation.KR.toNativeLanguage(),
+                            translateLanguage = Nation.KR.toTranslateLanguage(),
                         )
 
                     account.isOnboardingComplete() shouldBe false

--- a/src/test/kotlin/com/chat/chingudachi/domain/account/NationTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/domain/account/NationTest.kt
@@ -5,10 +5,10 @@ import io.kotest.matchers.shouldBe
 
 class NationTest : DescribeSpec() {
     init {
-        describe("toNativeLanguage") {
+        describe("toTranslateLanguage") {
             it("각 Nation에 맞춘 Language를 제공한다.") {
-                Nation.KR.toNativeLanguage() shouldBe NativeLanguage.KO
-                Nation.JP.toNativeLanguage() shouldBe NativeLanguage.JA
+                Nation.KR.toTranslateLanguage() shouldBe TranslateLanguage.JA
+                Nation.JP.toTranslateLanguage() shouldBe TranslateLanguage.KO
             }
         }
     }

--- a/src/test/kotlin/com/chat/chingudachi/fixture/AccountFixture.kt
+++ b/src/test/kotlin/com/chat/chingudachi/fixture/AccountFixture.kt
@@ -4,7 +4,7 @@ import com.chat.chingudachi.domain.account.Account
 import com.chat.chingudachi.domain.account.AccountStatus
 import com.chat.chingudachi.domain.account.AccountType
 import com.chat.chingudachi.domain.account.Nation
-import com.chat.chingudachi.domain.account.NativeLanguage
+import com.chat.chingudachi.domain.account.TranslateLanguage
 import com.chat.chingudachi.domain.account.Nickname
 import java.time.LocalDate
 
@@ -17,7 +17,7 @@ object AccountFixture {
         nickname: Nickname? = null,
         birthDate: LocalDate? = null,
         nation: Nation? = null,
-        nativeLanguage: NativeLanguage? = null,
+        translateLanguage: TranslateLanguage? = null,
     ): Account =
         Account(
             id = id,
@@ -27,6 +27,6 @@ object AccountFixture {
             nickname = nickname,
             birthDate = birthDate,
             nation = nation,
-            nativeLanguage = nativeLanguage,
+            translateLanguage = translateLanguage,
         )
 }

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountPersistenceTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountPersistenceTest.kt
@@ -1,7 +1,7 @@
 package com.chat.chingudachi.infrastructure.persistence.account
 
 import com.chat.chingudachi.domain.account.Nation
-import com.chat.chingudachi.domain.account.NativeLanguage
+import com.chat.chingudachi.domain.account.TranslateLanguage
 import com.chat.chingudachi.domain.account.Nickname
 import com.chat.chingudachi.fixture.AccountFixture
 import io.kotest.core.spec.style.DescribeSpec
@@ -28,7 +28,7 @@ class AccountPersistenceTest(
                     nickname = Nickname("테스트"),
                     birthDate = LocalDate.of(2000, 1, 1),
                     nation = Nation.KR,
-                    nativeLanguage = NativeLanguage.KO,
+                    translateLanguage = TranslateLanguage.JA,
                 )
 
                 val saved = accountRepository.saveAndFlush(account)
@@ -37,7 +37,7 @@ class AccountPersistenceTest(
                 val found = accountRepository.findById(saved.id).get()
                 found.nickname?.value shouldBe "테스트"
                 found.nation shouldBe Nation.KR
-                found.nativeLanguage shouldBe NativeLanguage.KO
+                found.translateLanguage shouldBe TranslateLanguage.JA
             }
 
             it("nickname이 null이어도 저장/조회가 정상 동작한다") {


### PR DESCRIPTION
## Summary

- `NativeLanguage` enum → `TranslateLanguage` enum 변경
- `Nation.toNativeLanguage()` → `Nation.toTranslateLanguage()` 매핑 반전 (KR→JA, JP→KO)
- Account entity: `nativeLanguage` 필드 → `translateLanguage` 필드
- 관련 테스트 전체 업데이트 (AccountTest, NationTest, AccountFixture, AccountPersistenceTest)

## Context

향후 사용자가 번역 대상 언어를 변경하거나 3개국어 확장 시 유연하게 대응하기 위해, `native_language`(모국어, 불변) → `translate_language`(번역 대상, 변경 가능) 구조로 재설계.

## Test plan

- [x] `./gradlew build` 컴파일 에러 없음
- [x] `./gradlew test` 모든 테스트 통과
- [x] `NativeLanguage`, `nativeLanguage`, `native_language` 잔여 참조 0건

Closes #16