### PR TITLE
feat: ErrorCode + BusinessException 에러 체계 도입

### DIFF
--- a/src/main/kotlin/com/chat/chingudachi/domain/common/BusinessException.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/BusinessException.kt
@@ -1,0 +1,36 @@
+package com.chat.chingudachi.domain.common
+
+sealed class BusinessException(
+    val errorCode: ErrorCode,
+    cause: Throwable? = null,
+) : RuntimeException(errorCode.message, cause)
+
+class BadRequestException(
+    errorCode: ErrorCode = ErrorCode.INVALID_INPUT,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)
+
+class UnauthorizedException(
+    errorCode: ErrorCode = ErrorCode.UNAUTHORIZED,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)
+
+class ForbiddenException(
+    errorCode: ErrorCode = ErrorCode.FORBIDDEN,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)
+
+class NotFoundException(
+    errorCode: ErrorCode = ErrorCode.RESOURCE_NOT_FOUND,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)
+
+class ConflictException(
+    errorCode: ErrorCode = ErrorCode.CONFLICT,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)
+
+class InternalServerException(
+    errorCode: ErrorCode = ErrorCode.INTERNAL_ERROR,
+    cause: Throwable? = null,
+) : BusinessException(errorCode, cause)

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -1,0 +1,28 @@
+package com.chat.chingudachi.domain.common
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorCode(
+    val status: HttpStatus,
+    val code: String,
+    val message: String,
+) {
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "Invalid input"),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", "Invalid parameter"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "Authentication required"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "Permission denied"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "Resource not found"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "Method not allowed"),
+    CONFLICT(HttpStatus.CONFLICT, "CONFLICT", "Resource conflict"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "An unexpected system error has occurred"),
+
+    // Account
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT_NOT_FOUND", "Account not found"),
+    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ACCOUNT_ALREADY_EXISTS", "Account already exists"),
+    ACCOUNT_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "ACCOUNT_NICKNAME_INVALID", "Nickname must be 2-12 characters without spaces"),
+
+    // Auth
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_EXPIRED", "Token has expired"),
+    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_INVALID", "Invalid token"),
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -4,25 +4,24 @@ import org.springframework.http.HttpStatus
 
 enum class ErrorCode(
     val status: HttpStatus,
-    val code: String,
     val message: String,
 ) {
     // Common
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "Invalid input"),
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "INVALID_PARAMETER", "Invalid parameter"),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "Authentication required"),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "Permission denied"),
-    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "Resource not found"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "Method not allowed"),
-    CONFLICT(HttpStatus.CONFLICT, "CONFLICT", "Resource conflict"),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "An unexpected system error has occurred"),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "Invalid input"),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "Invalid parameter"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Authentication required"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "Permission denied"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not found"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "Method not allowed"),
+    CONFLICT(HttpStatus.CONFLICT, "Resource conflict"),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected system error has occurred"),
 
     // Account
-    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "ACCOUNT_NOT_FOUND", "Account not found"),
-    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "ACCOUNT_ALREADY_EXISTS", "Account already exists"),
-    ACCOUNT_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "ACCOUNT_NICKNAME_INVALID", "Nickname must be 2-12 characters without spaces"),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "Account not found"),
+    ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "Account already exists"),
+    ACCOUNT_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "Nickname must be 2-12 characters without spaces"),
 
     // Auth
-    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_EXPIRED", "Token has expired"),
-    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_INVALID", "Invalid token"),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Token has expired"),
+    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Invalid token"),
 }

--- a/src/main/kotlin/com/chat/chingudachi/presentation/common/ApiResponse.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/common/ApiResponse.kt
@@ -1,8 +1,10 @@
 package com.chat.chingudachi.presentation.common
 
+import com.chat.chingudachi.domain.common.ErrorCode
 import java.time.Instant
 
 data class ApiResponse<T>(
+    val code: String?,
     val data: T?,
     val message: String,
     val isSuccess: Boolean,
@@ -13,18 +15,31 @@ data class ApiResponse<T>(
             data: T?,
             message: String = "success",
         ) = ApiResponse(
+            code = null,
             data = data,
             message = message,
             isSuccess = true,
             timestamp = Instant.now(),
         )
 
-        fun error(message: String) =
+        fun error(errorCode: ErrorCode) =
             ApiResponse(
+                code = errorCode.code,
                 data = null,
-                message = message,
+                message = errorCode.message,
                 isSuccess = false,
                 timestamp = Instant.now(),
             )
+
+        fun error(
+            code: String,
+            message: String,
+        ) = ApiResponse(
+            code = code,
+            data = null,
+            message = message,
+            isSuccess = false,
+            timestamp = Instant.now(),
+        )
     }
 }

--- a/src/main/kotlin/com/chat/chingudachi/presentation/common/ApiResponse.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/common/ApiResponse.kt
@@ -24,7 +24,7 @@ data class ApiResponse<T>(
 
         fun error(errorCode: ErrorCode) =
             ApiResponse(
-                code = errorCode.code,
+                code = errorCode.name,
                 data = null,
                 message = errorCode.message,
                 isSuccess = false,

--- a/src/test/kotlin/com/chat/chingudachi/domain/common/BusinessExceptionTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/domain/common/BusinessExceptionTest.kt
@@ -53,10 +53,10 @@ class BusinessExceptionTest : DescribeSpec() {
                     ErrorCode.AUTH_TOKEN_INVALID.status shouldBe HttpStatus.UNAUTHORIZED
                 }
 
-                it("code 문자열이 enum name과 일치한다.") {
-                    ErrorCode.entries.forEach { errorCode ->
-                        errorCode.code shouldBe errorCode.name
-                    }
+                it("name이 에러 코드 식별자로 사용된다.") {
+                    ErrorCode.INVALID_INPUT.name shouldBe "INVALID_INPUT"
+                    ErrorCode.ACCOUNT_NOT_FOUND.name shouldBe "ACCOUNT_NOT_FOUND"
+                    ErrorCode.AUTH_TOKEN_EXPIRED.name shouldBe "AUTH_TOKEN_EXPIRED"
                 }
             }
         }

--- a/src/test/kotlin/com/chat/chingudachi/domain/common/BusinessExceptionTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/domain/common/BusinessExceptionTest.kt
@@ -1,0 +1,64 @@
+package com.chat.chingudachi.domain.common
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.springframework.http.HttpStatus
+
+class BusinessExceptionTest : DescribeSpec() {
+    init {
+        describe("BusinessException") {
+            context("각 서브클래스 생성 시 ") {
+                it("ErrorCode의 message가 exception message로 설정된다.") {
+                    val ex = NotFoundException(ErrorCode.ACCOUNT_NOT_FOUND)
+
+                    ex.message shouldBe "Account not found"
+                    ex.errorCode shouldBe ErrorCode.ACCOUNT_NOT_FOUND
+                }
+
+                it("cause를 보존한다.") {
+                    val cause = RuntimeException("original error")
+                    val ex = BadRequestException(ErrorCode.INVALID_INPUT, cause)
+
+                    ex.cause shouldBe cause
+                }
+            }
+
+            context("sealed class 계층 확인 시 ") {
+                it("모든 서브클래스가 BusinessException의 인스턴스다.") {
+                    BadRequestException().shouldBeInstanceOf<BusinessException>()
+                    UnauthorizedException().shouldBeInstanceOf<BusinessException>()
+                    ForbiddenException().shouldBeInstanceOf<BusinessException>()
+                    NotFoundException().shouldBeInstanceOf<BusinessException>()
+                    ConflictException().shouldBeInstanceOf<BusinessException>()
+                    InternalServerException().shouldBeInstanceOf<BusinessException>()
+                }
+
+                it("기본 ErrorCode가 올바르게 설정된다.") {
+                    BadRequestException().errorCode shouldBe ErrorCode.INVALID_INPUT
+                    UnauthorizedException().errorCode shouldBe ErrorCode.UNAUTHORIZED
+                    ForbiddenException().errorCode shouldBe ErrorCode.FORBIDDEN
+                    NotFoundException().errorCode shouldBe ErrorCode.RESOURCE_NOT_FOUND
+                    ConflictException().errorCode shouldBe ErrorCode.CONFLICT
+                    InternalServerException().errorCode shouldBe ErrorCode.INTERNAL_ERROR
+                }
+            }
+
+            context("ErrorCode enum 확인 시 ") {
+                it("도메인 에러 코드는 올바른 HTTP 상태를 가진다.") {
+                    ErrorCode.ACCOUNT_NOT_FOUND.status shouldBe HttpStatus.NOT_FOUND
+                    ErrorCode.ACCOUNT_ALREADY_EXISTS.status shouldBe HttpStatus.CONFLICT
+                    ErrorCode.ACCOUNT_NICKNAME_INVALID.status shouldBe HttpStatus.BAD_REQUEST
+                    ErrorCode.AUTH_TOKEN_EXPIRED.status shouldBe HttpStatus.UNAUTHORIZED
+                    ErrorCode.AUTH_TOKEN_INVALID.status shouldBe HttpStatus.UNAUTHORIZED
+                }
+
+                it("code 문자열이 enum name과 일치한다.") {
+                    ErrorCode.entries.forEach { errorCode ->
+                        errorCode.code shouldBe errorCode.name
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 에러 응답에 `code` 필드 추가하여 프론트엔드가 에러 유형을 식별할 수 있도록 함
- `ErrorCode` enum + `BusinessException` sealed class 도입으로 체계적 에러 처리
- `IllegalArgumentException` 등 기존 500 처리되던 예외를 적절한 HTTP 상태로 매핑

## Changes
- `ErrorCode` enum 신규 (공통 8개 + Account 3개 + Auth 2개)
- `BusinessException` sealed class 계층 (BadRequest, Unauthorized, Forbidden, NotFound, Conflict, InternalServer)
- `ApiResponse`에 `code: String?` 필드 추가, `error(ErrorCode)` + `error(code, message)` 팩토리
- `ErrorResponseWrappingAdvice`에 BusinessException, IllegalArgumentException, NoResourceFoundException 핸들러 추가
- `BusinessExceptionTest` 단위 테스트

## Notes
- `ErrorCode`에 `HttpStatus` 의존: 이미 domain에 Spring 의존(`BaseTimeEntity`)이 있으므로 프로젝트 일관성 유지

Closes #36