### PR TITLE
feat: Auth 도메인 + JWT 인프라 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
 
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.13.0")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.13.0")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.13.0")
+
     // Database
     runtimeOnly("org.postgresql:postgresql")
 

--- a/docs/backend/auth-jwt.md
+++ b/docs/backend/auth-jwt.md
@@ -1,0 +1,64 @@
+# Auth 도메인 + JWT 인프라
+
+## 개요
+
+인증 인프라의 기반 레이어. JWT 토큰 생성/검증과 Auth 도메인 모델을 구축하여
+이후 OAuth 연동(BE-05), Security Filter(BE-06)의 토대를 마련한다.
+
+## 아키텍처
+
+```
+[JwtProvider]                     [AuthTokenRepository]
+     │                                    │
+     ├─ createAccessToken(accountId)      ├─ findByAccountIdAndRefreshToken()
+     ├─ createRefreshToken(accountId)     ├─ deleteByAccountId()
+     ├─ validateToken(token) → Boolean    └─ deleteByExpiresAtBefore()
+     └─ parseAccountId(token) → Long
+              │
+              ├─ 만료 → UnauthorizedException(AUTH_TOKEN_EXPIRED)
+              └─ 위변조 → UnauthorizedException(AUTH_TOKEN_INVALID)
+```
+
+## 도메인 모델
+
+| 클래스 | 유형 | 역할 |
+|--------|------|------|
+| `AuthToken` | Entity | 리프레시 토큰 저장 + 만료 판단 (`isExpired()`) |
+| `TokenPair` | Value Object | access/refresh 토큰 쌍 |
+| `OAuthUserInfo` | Value Object | OAuth 인증 후 사용자 정보 추상화 |
+
+## JWT 설정
+
+| 항목 | 로컬 | 테스트 |
+|------|------|--------|
+| access-token-expiry | 1h | 10s |
+| refresh-token-expiry | 30d | 1m |
+| secret | Base64 256bit | Base64 256bit (별도) |
+
+- `JwtProperties`로 외부화 (`@ConfigurationProperties(prefix = "jwt")`)
+- `JwtProvider`에서 `@EnableConfigurationProperties`로 등록
+
+## 에러 처리
+
+`ExpiredJwtException`과 기타 `JwtException`을 분리하여 클라이언트가 토큰 갱신 여부를 판단할 수 있게 함.
+
+| jjwt 예외 | ErrorCode | 의미 |
+|-----------|-----------|------|
+| `ExpiredJwtException` | `AUTH_TOKEN_EXPIRED` | 토큰 만료 → refresh 시도 |
+| `SignatureException`, `MalformedJwtException` | `AUTH_TOKEN_INVALID` | 위변조/형식 오류 |
+
+기존 `ErrorResponseWrappingAdvice`가 `UnauthorizedException` → HTTP 401 + `ApiResponse.error()` 변환.
+
+## 테스트
+
+| 테스트 | 유형 | 케이스 수 |
+|--------|------|-----------|
+| `AuthTokenTest` | 순수 단위 | 2 (만료 판단) |
+| `JwtProviderTest` | 순수 단위 | 12 (생성/검증/파싱/에러) |
+| `AuthTokenRepositoryTest` | 영속성 (Embedded PG) | 5 (CRUD/쿼리) |
+
+## 의존성
+
+- `io.jsonwebtoken:jjwt-api:0.13.0` (compile)
+- `io.jsonwebtoken:jjwt-impl:0.13.0` (runtime)
+- `io.jsonwebtoken:jjwt-jackson:0.13.0` (runtime)

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/AuthToken.kt
@@ -19,14 +19,13 @@ class AuthToken(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "auth_token_id")
     val id: Long = 0,
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id", nullable = false)
     val account: Account,
-
     @Column(name = "refresh_token", nullable = false, length = 500)
     val refreshToken: String,
-
     @Column(name = "expires_at", nullable = false)
     val expiresAt: Instant,
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    fun isExpired(): Boolean = expiresAt < Instant.now()
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthProvider.kt
@@ -1,0 +1,5 @@
+package com.chat.chingudachi.domain.auth
+
+enum class OAuthProvider {
+    GOOGLE,
+}

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthUserInfo.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthUserInfo.kt
@@ -1,7 +1,7 @@
 package com.chat.chingudachi.domain.auth
 
 data class OAuthUserInfo(
-    val provider: String,
-    val sub: String,
+    val provider: OAuthProvider,
+    val providerUserId: String,
     val email: String,
 )

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthUserInfo.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/OAuthUserInfo.kt
@@ -1,0 +1,7 @@
+package com.chat.chingudachi.domain.auth
+
+data class OAuthUserInfo(
+    val provider: String,
+    val sub: String,
+    val email: String,
+)

--- a/src/main/kotlin/com/chat/chingudachi/domain/auth/TokenPair.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/auth/TokenPair.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.domain.auth
+
+data class TokenPair(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProperties.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProperties.kt
@@ -1,0 +1,11 @@
+package com.chat.chingudachi.infrastructure.jwt
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "jwt")
+data class JwtProperties(
+    val secret: String,
+    val accessTokenExpiry: Duration,
+    val refreshTokenExpiry: Duration,
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
@@ -1,0 +1,69 @@
+package com.chat.chingudachi.infrastructure.jwt
+
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Component
+import java.util.Date
+import javax.crypto.SecretKey
+
+@Component
+@EnableConfigurationProperties(JwtProperties::class)
+class JwtProvider(
+    private val jwtProperties: JwtProperties,
+) {
+    private val secretKey: SecretKey = Keys.hmacShaKeyFor(
+        Decoders.BASE64.decode(jwtProperties.secret),
+    )
+
+    fun createAccessToken(accountId: Long): String =
+        createToken(accountId, jwtProperties.accessTokenExpiry.toMillis())
+
+    fun createRefreshToken(accountId: Long): String =
+        createToken(accountId, jwtProperties.refreshTokenExpiry.toMillis())
+
+    fun validateToken(token: String): Boolean =
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+            true
+        } catch (e: JwtException) {
+            false
+        } catch (e: IllegalArgumentException) {
+            false
+        }
+
+    fun parseAccountId(token: String): Long =
+        try {
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+                .subject
+                .toLong()
+        } catch (e: ExpiredJwtException) {
+            throw UnauthorizedException(ErrorCode.AUTH_TOKEN_EXPIRED, e)
+        } catch (e: JwtException) {
+            throw UnauthorizedException(ErrorCode.AUTH_TOKEN_INVALID, e)
+        } catch (e: IllegalArgumentException) {
+            throw UnauthorizedException(ErrorCode.AUTH_TOKEN_INVALID, e)
+        }
+
+    private fun createToken(accountId: Long, expiryMillis: Long): String {
+        val now = System.currentTimeMillis()
+        return Jwts.builder()
+            .subject(accountId.toString())
+            .issuedAt(Date(now))
+            .expiration(Date(now + expiryMillis))
+            .signWith(secretKey)
+            .compact()
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
@@ -1,6 +1,7 @@
 package com.chat.chingudachi.infrastructure.persistence.auth
 
 import com.chat.chingudachi.domain.auth.AuthToken
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import java.time.Instant
@@ -9,8 +10,10 @@ interface AuthTokenRepository : JpaRepository<AuthToken, Long> {
     fun findByAccountIdAndRefreshToken(accountId: Long, refreshToken: String): AuthToken?
 
     @Modifying
+    @Transactional
     fun deleteByAccountId(accountId: Long)
 
     @Modifying
+    @Transactional
     fun deleteByExpiresAtBefore(now: Instant)
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepository.kt
@@ -2,5 +2,15 @@ package com.chat.chingudachi.infrastructure.persistence.auth
 
 import com.chat.chingudachi.domain.auth.AuthToken
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import java.time.Instant
 
-interface AuthTokenRepository : JpaRepository<AuthToken, Long>
+interface AuthTokenRepository : JpaRepository<AuthToken, Long> {
+    fun findByAccountIdAndRefreshToken(accountId: Long, refreshToken: String): AuthToken?
+
+    @Modifying
+    fun deleteByAccountId(accountId: Long)
+
+    @Modifying
+    fun deleteByExpiresAtBefore(now: Instant)
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -17,3 +17,8 @@ spring:
 cors:
   allowed-origins:
     - "http://localhost:3000"
+
+jwt:
+  secret: "Y2hpbmd1ZGFjaGktand0LXNlY3JldC1rZXktZm9yLWxvY2FsLWRldi0yNTZiaXQ"
+  access-token-expiry: 1h
+  refresh-token-expiry: 30d

--- a/src/test/kotlin/com/chat/chingudachi/domain/auth/AuthTokenTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/domain/auth/AuthTokenTest.kt
@@ -1,0 +1,37 @@
+package com.chat.chingudachi.domain.auth
+
+import com.chat.chingudachi.fixture.AccountFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.Instant
+
+class AuthTokenTest : DescribeSpec() {
+    init {
+        describe("AuthToken의") {
+            context("isExpired") {
+                it("만료 시점이 현재보다 과거이면 true를 반환한다") {
+                    val token =
+                        AuthToken(
+                            account = AccountFixture.create(),
+                            refreshToken = "test-refresh-token",
+                            expiresAt = Instant.now().minus(Duration.ofHours(1)),
+                        )
+
+                    token.isExpired() shouldBe true
+                }
+
+                it("만료 시점이 현재보다 미래이면 false를 반환한다") {
+                    val token =
+                        AuthToken(
+                            account = AccountFixture.create(),
+                            refreshToken = "test-refresh-token",
+                            expiresAt = Instant.now().plus(Duration.ofHours(1)),
+                        )
+
+                    token.isExpired() shouldBe false
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/fixture/AuthTokenFixture.kt
+++ b/src/test/kotlin/com/chat/chingudachi/fixture/AuthTokenFixture.kt
@@ -1,0 +1,21 @@
+package com.chat.chingudachi.fixture
+
+import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.auth.AuthToken
+import java.time.Duration
+import java.time.Instant
+
+object AuthTokenFixture {
+    fun create(
+        id: Long = 0L,
+        account: Account = AccountFixture.create(id = 0L),
+        refreshToken: String = "test-refresh-token",
+        expiresAt: Instant = Instant.now().plus(Duration.ofDays(30)),
+    ): AuthToken =
+        AuthToken(
+            id = id,
+            account = account,
+            refreshToken = refreshToken,
+            expiresAt = expiresAt,
+        )
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProviderTest.kt
@@ -1,0 +1,147 @@
+package com.chat.chingudachi.infrastructure.jwt
+
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import java.time.Duration
+import java.util.Base64
+
+class JwtProviderTest : DescribeSpec() {
+    private val testSecret = Base64.getEncoder().encodeToString(
+        "chingudachi-test-secret-key-256b".toByteArray(),
+    )
+    private val differentSecret = Base64.getEncoder().encodeToString(
+        "different-test-secret-key-256bit".toByteArray(),
+    )
+
+    private val jwtProvider = JwtProvider(
+        JwtProperties(
+            secret = testSecret,
+            accessTokenExpiry = Duration.ofHours(1),
+            refreshTokenExpiry = Duration.ofDays(30),
+        ),
+    )
+
+    init {
+        describe("createAccessToken") {
+            it("accountId로 access token을 생성한다") {
+                val token = jwtProvider.createAccessToken(1L)
+
+                token.shouldNotBeEmpty()
+            }
+
+            it("생성된 토큰에서 accountId를 추출할 수 있다") {
+                val accountId = 42L
+                val token = jwtProvider.createAccessToken(accountId)
+
+                jwtProvider.parseAccountId(token) shouldBe accountId
+            }
+        }
+
+        describe("createRefreshToken") {
+            it("accountId로 refresh token을 생성한다") {
+                val token = jwtProvider.createRefreshToken(1L)
+
+                token.shouldNotBeEmpty()
+            }
+
+            it("access token과 refresh token은 서로 다르다") {
+                val accountId = 1L
+                val accessToken = jwtProvider.createAccessToken(accountId)
+                val refreshToken = jwtProvider.createRefreshToken(accountId)
+
+                accessToken shouldNotBe refreshToken
+            }
+        }
+
+        describe("validateToken") {
+            it("유효한 토큰이면 true를 반환한다") {
+                val token = jwtProvider.createAccessToken(1L)
+
+                jwtProvider.validateToken(token) shouldBe true
+            }
+
+            it("만료된 토큰이면 false를 반환한다") {
+                val expiredProvider = JwtProvider(
+                    JwtProperties(
+                        secret = testSecret,
+                        accessTokenExpiry = Duration.ZERO,
+                        refreshTokenExpiry = Duration.ZERO,
+                    ),
+                )
+                val token = expiredProvider.createAccessToken(1L)
+
+                expiredProvider.validateToken(token) shouldBe false
+            }
+
+            it("다른 키로 서명된 토큰이면 false를 반환한다") {
+                val otherProvider = JwtProvider(
+                    JwtProperties(
+                        secret = differentSecret,
+                        accessTokenExpiry = Duration.ofHours(1),
+                        refreshTokenExpiry = Duration.ofDays(30),
+                    ),
+                )
+                val token = otherProvider.createAccessToken(1L)
+
+                jwtProvider.validateToken(token) shouldBe false
+            }
+
+            it("형식이 잘못된 토큰이면 false를 반환한다") {
+                jwtProvider.validateToken("invalid.token.here") shouldBe false
+            }
+        }
+
+        describe("parseAccountId") {
+            it("정상 토큰에서 accountId를 추출한다") {
+                val accountId = 99L
+                val token = jwtProvider.createAccessToken(accountId)
+
+                jwtProvider.parseAccountId(token) shouldBe accountId
+            }
+
+            it("만료된 토큰이면 AUTH_TOKEN_EXPIRED 예외를 던진다") {
+                val expiredProvider = JwtProvider(
+                    JwtProperties(
+                        secret = testSecret,
+                        accessTokenExpiry = Duration.ZERO,
+                        refreshTokenExpiry = Duration.ZERO,
+                    ),
+                )
+                val token = expiredProvider.createAccessToken(1L)
+
+                val exception = shouldThrow<UnauthorizedException> {
+                    jwtProvider.parseAccountId(token)
+                }
+                exception.errorCode shouldBe ErrorCode.AUTH_TOKEN_EXPIRED
+            }
+
+            it("잘못된 토큰이면 AUTH_TOKEN_INVALID 예외를 던진다") {
+                val exception = shouldThrow<UnauthorizedException> {
+                    jwtProvider.parseAccountId("invalid-token")
+                }
+                exception.errorCode shouldBe ErrorCode.AUTH_TOKEN_INVALID
+            }
+
+            it("다른 키로 서명된 토큰이면 AUTH_TOKEN_INVALID 예외를 던진다") {
+                val otherProvider = JwtProvider(
+                    JwtProperties(
+                        secret = differentSecret,
+                        accessTokenExpiry = Duration.ofHours(1),
+                        refreshTokenExpiry = Duration.ofDays(30),
+                    ),
+                )
+                val token = otherProvider.createAccessToken(1L)
+
+                val exception = shouldThrow<UnauthorizedException> {
+                    jwtProvider.parseAccountId(token)
+                }
+                exception.errorCode shouldBe ErrorCode.AUTH_TOKEN_INVALID
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProviderTest.kt
@@ -69,8 +69,8 @@ class JwtProviderTest : DescribeSpec() {
                 val expiredProvider = JwtProvider(
                     JwtProperties(
                         secret = testSecret,
-                        accessTokenExpiry = Duration.ZERO,
-                        refreshTokenExpiry = Duration.ZERO,
+                        accessTokenExpiry = Duration.ofMillis(-1),
+                        refreshTokenExpiry = Duration.ofMillis(-1),
                     ),
                 )
                 val token = expiredProvider.createAccessToken(1L)
@@ -108,8 +108,8 @@ class JwtProviderTest : DescribeSpec() {
                 val expiredProvider = JwtProvider(
                     JwtProperties(
                         secret = testSecret,
-                        accessTokenExpiry = Duration.ZERO,
-                        refreshTokenExpiry = Duration.ZERO,
+                        accessTokenExpiry = Duration.ofMillis(-1),
+                        refreshTokenExpiry = Duration.ofMillis(-1),
                     ),
                 )
                 val token = expiredProvider.createAccessToken(1L)

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepositoryTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepositoryTest.kt
@@ -5,8 +5,8 @@ import com.chat.chingudachi.fixture.AuthTokenFixture
 import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase
 import jakarta.persistence.EntityManager
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
@@ -60,8 +60,8 @@ class AuthTokenRepositoryTest(
                     refreshToken = "matching-token",
                 )
 
-                found shouldNotBe null
-                found!!.id shouldBe authToken.id
+                found.shouldNotBeNull()
+                found.id shouldBe authToken.id
             }
 
             it("일치하지 않는 refreshToken이면 null을 반환한다") {

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepositoryTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/auth/AuthTokenRepositoryTest.kt
@@ -1,0 +1,142 @@
+package com.chat.chingudachi.infrastructure.persistence.auth
+
+import com.chat.chingudachi.fixture.AccountFixture
+import com.chat.chingudachi.fixture.AuthTokenFixture
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import jakarta.persistence.EntityManager
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+import java.time.Instant
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureEmbeddedDatabase
+class AuthTokenRepositoryTest(
+    private val authTokenRepository: AuthTokenRepository,
+    private val accountRepository: AccountRepository,
+    private val entityManager: EntityManager,
+) : DescribeSpec() {
+    init {
+        describe("AuthToken 영속성") {
+            it("AuthToken을 저장하고 조회할 수 있다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                val authToken = AuthTokenFixture.create(
+                    account = account,
+                    refreshToken = "saved-refresh-token",
+                )
+
+                val saved = authTokenRepository.saveAndFlush(authToken)
+                entityManager.clear()
+
+                val found = authTokenRepository.findById(saved.id).get()
+                found.refreshToken shouldBe "saved-refresh-token"
+                found.account.id shouldBe account.id
+            }
+        }
+
+        describe("findByAccountIdAndRefreshToken") {
+            it("accountId와 refreshToken으로 조회할 수 있다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                val authToken = authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = "matching-token",
+                    ),
+                )
+                entityManager.clear()
+
+                val found = authTokenRepository.findByAccountIdAndRefreshToken(
+                    accountId = account.id,
+                    refreshToken = "matching-token",
+                )
+
+                found shouldNotBe null
+                found!!.id shouldBe authToken.id
+            }
+
+            it("일치하지 않는 refreshToken이면 null을 반환한다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = "original-token",
+                    ),
+                )
+                entityManager.clear()
+
+                val found = authTokenRepository.findByAccountIdAndRefreshToken(
+                    accountId = account.id,
+                    refreshToken = "wrong-token",
+                )
+
+                found shouldBe null
+            }
+        }
+
+        describe("deleteByAccountId") {
+            it("해당 accountId의 모든 토큰을 삭제한다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(account = account, refreshToken = "token-1"),
+                )
+                authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(account = account, refreshToken = "token-2"),
+                )
+                entityManager.flush()
+                entityManager.clear()
+
+                authTokenRepository.deleteByAccountId(account.id)
+                entityManager.flush()
+                entityManager.clear()
+
+                authTokenRepository.findAll() shouldHaveSize 0
+            }
+        }
+
+        describe("deleteByExpiresAtBefore") {
+            it("만료된 토큰만 삭제한다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = "expired-token",
+                        expiresAt = Instant.now().minus(Duration.ofDays(1)),
+                    ),
+                )
+                authTokenRepository.saveAndFlush(
+                    AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = "valid-token",
+                        expiresAt = Instant.now().plus(Duration.ofDays(30)),
+                    ),
+                )
+                entityManager.flush()
+                entityManager.clear()
+
+                authTokenRepository.deleteByExpiresAtBefore(Instant.now())
+                entityManager.flush()
+                entityManager.clear()
+
+                val remaining = authTokenRepository.findAll()
+                remaining shouldHaveSize 1
+                remaining[0].refreshToken shouldBe "valid-token"
+            }
+        }
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -9,3 +9,8 @@ spring:
   docker:
     compose:
       enabled: false
+
+jwt:
+  secret: "dGVzdC1qd3Qtc2VjcmV0LWtleS1mb3ItdGVzdGluZy1vbmx5LTI1NmJpdHM="
+  access-token-expiry: 10s
+  refresh-token-expiry: 1m


### PR DESCRIPTION
## Summary
- JWT 토큰 생성/검증/파싱 인프라 구축
- Auth 도메인 모델(AuthToken, TokenPair, OAuthUserInfo) 정의
- BE-05(Google OAuth), BE-06(Security Filter)의 토대

## Changes
- jjwt 0.13.0 의존성 추가 (api/impl/jackson 분리)
- `JwtProvider`: access/refresh 토큰 생성, 검증, accountId 파싱
- `JwtProperties`: JWT 설정 외부화 (@ConfigurationProperties)
- `AuthToken.isExpired()`: 도메인 레벨 만료 판단 로직
- `AuthTokenRepository`: 쿼리 메서드 3개 (조회/삭제/만료정리)
- `TokenPair`, `OAuthUserInfo` Value Object 생성
- 에러코드 분리: `AUTH_TOKEN_EXPIRED` vs `AUTH_TOKEN_INVALID`

## Test
- AuthTokenTest: 2 cases (만료 판단)
- JwtProviderTest: 12 cases (생성/검증/파싱/에러)
- AuthTokenRepositoryTest: 5 cases (영속성/쿼리)
- 전체 테스트 통과 확인

## Notes
- `ExpiredJwtException`을 `JwtException`보다 먼저 catch하여 에러코드 분리
- 테스트용 JWT secret은 프로덕션과 별도 (application-test.yaml)

Closes #5