### PR TITLE
feat: Google OAuth 연동 + AuthenticateUseCase

### DIFF
--- a/docs/backend/google-oauth.md
+++ b/docs/backend/google-oauth.md
@@ -1,0 +1,100 @@
+# Google OAuth 연동 + AuthenticateUseCase
+
+## 개요
+
+Google OAuth 2.0 인증 흐름의 핵심 비즈니스 로직.
+프로젝트 최초의 UseCase(application layer)로, Clean Architecture의 핵심 계층을 완성한다.
+
+## 아키텍처
+
+```
+[Presentation]           [Application]              [Infrastructure]
+                    AuthenticateUseCase
+                         │    │
+                 OAuthClient(port)──────► GoogleOAuthClient
+                         │                     │
+                         │               RestClient → Google API
+                         │
+                  AccountRepository
+                  AccountCredentialRepository
+                  AuthTokenRepository
+                  JwtProvider
+```
+
+핵심: `OAuthClient`는 application 레이어의 포트 인터페이스.
+Infrastructure의 `GoogleOAuthClient`가 구현 → DIP 준수.
+
+## 인증 흐름
+
+```
+1. 프론트에서 Google 로그인 → authorization code 획득
+2. POST /api/auth/google { code }
+3. AuthenticateUseCase.authenticate(code)
+   ├─ GoogleOAuthClient.authenticate(code)
+   │   ├─ code → Google Token API → access_token
+   │   └─ access_token → Google UserInfo API → sub, email
+   ├─ findOrCreateAccount
+   │   ├─ AccountCredentialRepository.findByCredentialTypeAndOauthKey()
+   │   ├─ 기존 유저 → 기존 Account 반환
+   │   └─ 신규 유저 → Account(NOT_CONSENT) + Credential 생성
+   ├─ 기존 refresh token 전체 삭제 (단일 디바이스 정책)
+   ├─ 새 TokenPair(access + refresh) 생성
+   └─ AuthenticateResult 반환 (tokens + onboardingRequired)
+```
+
+## 주요 파일
+
+### Application Layer
+
+| 파일 | 역할 |
+|------|------|
+| `application/auth/AuthenticateUseCase.kt` | 인증 핵심 비즈니스 로직 |
+| `application/auth/port/OAuthClient.kt` | OAuth 포트 인터페이스 (DIP) |
+| `application/auth/command/AuthenticateCommand.kt` | 입력 DTO |
+| `application/auth/result/AuthenticateResult.kt` | 출력 DTO |
+
+### Infrastructure Layer
+
+| 파일 | 역할 |
+|------|------|
+| `infrastructure/oauth/GoogleOAuthClient.kt` | OAuthClient 구현체 (RestClient) |
+| `infrastructure/oauth/GoogleOAuthProperties.kt` | Google OAuth 설정 |
+| `infrastructure/oauth/dto/GoogleTokenResponse.kt` | Google 토큰 응답 DTO |
+| `infrastructure/oauth/dto/GoogleUserInfoResponse.kt` | Google 유저정보 응답 DTO |
+| `infrastructure/persistence/account/AccountCredentialRepository.kt` | Credential JPA 조회 |
+| `infrastructure/config/RestClientConfig.kt` | RestClient 빈 등록 |
+
+## 설계 결정
+
+| 결정 | 이유 |
+|------|------|
+| OAuthClient 포트 인터페이스 | application → infrastructure 직접 참조 금지 (DIP) |
+| AuthenticateUseCase는 concrete class | 구현체 1개, 인터페이스 불필요 |
+| RestClient 사용 | Spring Boot 4.x 권장 (RestTemplate deprecated) |
+| 로그인 시 기존 refresh token 전체 삭제 | 단일 디바이스 정책 (MVP) |
+| 신규 유저 상태 NOT_CONSENT | 약관 동의 → 온보딩 순서 |
+
+## 에러 처리
+
+| ErrorCode | HTTP | 상황 |
+|-----------|------|------|
+| `AUTH_OAUTH_CODE_INVALID` | 401 | Google 토큰 교환 실패 (잘못된 code) |
+| `AUTH_OAUTH_PROVIDER_ERROR` | 502 | Google UserInfo API 통신 실패 |
+
+## OAuth 설정
+
+| 항목 | 로컬 | 테스트 |
+|------|------|--------|
+| client-id | 환경변수 `GOOGLE_CLIENT_ID` | test-client-id |
+| client-secret | 환경변수 `GOOGLE_CLIENT_SECRET` | test-client-secret |
+| redirect-uri | http://localhost:3000/auth/callback | 동일 |
+| token-uri | https://oauth2.googleapis.com/token (기본값) | 동일 |
+| user-info-uri | https://www.googleapis.com/oauth2/v3/userinfo (기본값) | 동일 |
+
+## 테스트
+
+| 테스트 | 유형 | 케이스 수 |
+|--------|------|-----------|
+| `AuthenticateUseCaseTest` | Unit (MockK) | 5 (신규/기존/온보딩/토큰삭제/실패) |
+| `GoogleOAuthClientTest` | Unit (MockRestServiceServer) | 3 (정상/토큰실패/정보실패) |
+| `AccountCredentialRepositoryTest` | 영속성 (Embedded PG) | 3 (저장/조회/미존재) |

--- a/src/main/kotlin/com/chat/chingudachi/ChinguDachiApplication.kt
+++ b/src/main/kotlin/com/chat/chingudachi/ChinguDachiApplication.kt
@@ -1,12 +1,12 @@
 package com.chat.chingudachi
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import java.util.TimeZone
 
-@EnableConfigurationProperties
+@ConfigurationPropertiesScan
 @SpringBootApplication
 @EnableJpaAuditing
 class ChinguDachiApplication

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
@@ -1,0 +1,93 @@
+package com.chat.chingudachi.application.auth
+
+import com.chat.chingudachi.application.auth.command.AuthenticateCommand
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.application.auth.result.AuthenticateResult
+import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.account.AccountCredential
+import com.chat.chingudachi.domain.account.AccountStatus
+import com.chat.chingudachi.domain.account.AccountType
+import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.auth.AuthToken
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+import com.chat.chingudachi.infrastructure.jwt.JwtProvider
+import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+
+@Service
+@Transactional
+class AuthenticateUseCase(
+    private val oAuthClient: OAuthClient,
+    private val accountRepository: AccountRepository,
+    private val accountCredentialRepository: AccountCredentialRepository,
+    private val authTokenRepository: AuthTokenRepository,
+    private val jwtProvider: JwtProvider,
+) {
+    fun authenticate(command: AuthenticateCommand): AuthenticateResult {
+        val oAuthUserInfo = oAuthClient.authenticate(command.code)
+        val account = findOrCreateAccount(oAuthUserInfo)
+
+        val accessToken = jwtProvider.createAccessToken(account.id)
+        val refreshToken = jwtProvider.createRefreshToken(account.id)
+
+        authTokenRepository.deleteByAccountId(account.id)
+        authTokenRepository.save(
+            AuthToken(
+                account = account,
+                refreshToken = refreshToken,
+                expiresAt = Instant.now().plus(REFRESH_TOKEN_TTL),
+            ),
+        )
+
+        return AuthenticateResult(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            onboardingRequired = !account.isOnboardingComplete(),
+        )
+    }
+
+    private fun findOrCreateAccount(oAuthUserInfo: OAuthUserInfo): Account {
+        val credentialType = toCredentialType(oAuthUserInfo.provider)
+        val existing = accountCredentialRepository.findByCredentialTypeAndOauthKey(
+            credentialType = credentialType,
+            oauthKey = oAuthUserInfo.providerUserId,
+        )
+
+        if (existing != null) {
+            return existing.account
+        }
+
+        val account = accountRepository.save(
+            Account(
+                accountType = AccountType.USER,
+                accountStatus = AccountStatus.NOT_CONSENT,
+                email = oAuthUserInfo.email,
+            ),
+        )
+
+        accountCredentialRepository.save(
+            AccountCredential(
+                account = account,
+                credentialType = credentialType,
+                oauthKey = oAuthUserInfo.providerUserId,
+            ),
+        )
+
+        return account
+    }
+
+    private fun toCredentialType(provider: OAuthProvider): CredentialType =
+        when (provider) {
+            OAuthProvider.GOOGLE -> CredentialType.GOOGLE_OAUTH
+        }
+
+    companion object {
+        private val REFRESH_TOKEN_TTL = Duration.ofDays(30)
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
@@ -1,7 +1,11 @@
 package com.chat.chingudachi.application.auth
 
 import com.chat.chingudachi.application.auth.command.AuthenticateCommand
+import com.chat.chingudachi.application.auth.port.AccountCredentialStore
+import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.application.auth.port.AuthTokenStore
 import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.application.auth.port.TokenProvider
 import com.chat.chingudachi.application.auth.result.AuthenticateResult
 import com.chat.chingudachi.domain.account.Account
 import com.chat.chingudachi.domain.account.AccountCredential
@@ -11,10 +15,6 @@ import com.chat.chingudachi.domain.account.CredentialType
 import com.chat.chingudachi.domain.auth.AuthToken
 import com.chat.chingudachi.domain.auth.OAuthProvider
 import com.chat.chingudachi.domain.auth.OAuthUserInfo
-import com.chat.chingudachi.infrastructure.jwt.JwtProvider
-import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
-import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
-import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -24,20 +24,53 @@ import java.time.Instant
 @Transactional
 class AuthenticateUseCase(
     private val oAuthClient: OAuthClient,
-    private val accountRepository: AccountRepository,
-    private val accountCredentialRepository: AccountCredentialRepository,
-    private val authTokenRepository: AuthTokenRepository,
-    private val jwtProvider: JwtProvider,
+    private val accountStore: AccountStore,
+    private val accountCredentialStore: AccountCredentialStore,
+    private val authTokenStore: AuthTokenStore,
+    private val tokenProvider: TokenProvider,
 ) {
     fun authenticate(command: AuthenticateCommand): AuthenticateResult {
         val oAuthUserInfo = oAuthClient.authenticate(command.code)
         val account = findOrCreateAccount(oAuthUserInfo)
+        return issueTokens(account)
+    }
 
-        val accessToken = jwtProvider.createAccessToken(account.id)
-        val refreshToken = jwtProvider.createRefreshToken(account.id)
+    private fun findOrCreateAccount(oAuthUserInfo: OAuthUserInfo): Account {
+        val credentialType = toCredentialType(oAuthUserInfo.provider)
+        val existing = accountCredentialStore.findByCredentialTypeAndOauthKey(
+            credentialType = credentialType,
+            oauthKey = oAuthUserInfo.providerUserId,
+        )
 
-        authTokenRepository.deleteByAccountId(account.id)
-        authTokenRepository.save(
+        if (existing != null) {
+            return existing.account
+        }
+
+        val account = accountStore.save(
+            Account(
+                accountType = AccountType.USER,
+                accountStatus = AccountStatus.NOT_CONSENT,
+                email = oAuthUserInfo.email,
+            ),
+        )
+
+        accountCredentialStore.save(
+            AccountCredential(
+                account = account,
+                credentialType = credentialType,
+                oauthKey = oAuthUserInfo.providerUserId,
+            ),
+        )
+
+        return account
+    }
+
+    private fun issueTokens(account: Account): AuthenticateResult {
+        val accessToken = tokenProvider.createAccessToken(account.id)
+        val refreshToken = tokenProvider.createRefreshToken(account.id)
+
+        authTokenStore.deleteByAccountId(account.id)
+        authTokenStore.save(
             AuthToken(
                 account = account,
                 refreshToken = refreshToken,
@@ -50,36 +83,6 @@ class AuthenticateUseCase(
             refreshToken = refreshToken,
             onboardingRequired = !account.isOnboardingComplete(),
         )
-    }
-
-    private fun findOrCreateAccount(oAuthUserInfo: OAuthUserInfo): Account {
-        val credentialType = toCredentialType(oAuthUserInfo.provider)
-        val existing = accountCredentialRepository.findByCredentialTypeAndOauthKey(
-            credentialType = credentialType,
-            oauthKey = oAuthUserInfo.providerUserId,
-        )
-
-        if (existing != null) {
-            return existing.account
-        }
-
-        val account = accountRepository.save(
-            Account(
-                accountType = AccountType.USER,
-                accountStatus = AccountStatus.NOT_CONSENT,
-                email = oAuthUserInfo.email,
-            ),
-        )
-
-        accountCredentialRepository.save(
-            AccountCredential(
-                account = account,
-                credentialType = credentialType,
-                oauthKey = oAuthUserInfo.providerUserId,
-            ),
-        )
-
-        return account
     }
 
     private fun toCredentialType(provider: OAuthProvider): CredentialType =

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/command/AuthenticateCommand.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/command/AuthenticateCommand.kt
@@ -1,0 +1,5 @@
+package com.chat.chingudachi.application.auth.command
+
+data class AuthenticateCommand(
+    val code: String,
+)

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/OAuthClient.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/OAuthClient.kt
@@ -1,0 +1,7 @@
+package com.chat.chingudachi.application.auth.port
+
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+
+interface OAuthClient {
+    fun authenticate(code: String): OAuthUserInfo
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
@@ -1,0 +1,20 @@
+package com.chat.chingudachi.application.auth.port
+
+import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.account.AccountCredential
+import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.auth.AuthToken
+
+interface AccountStore {
+    fun save(account: Account): Account
+}
+
+interface AccountCredentialStore {
+    fun save(credential: AccountCredential): AccountCredential
+    fun findByCredentialTypeAndOauthKey(credentialType: CredentialType, oauthKey: String): AccountCredential?
+}
+
+interface AuthTokenStore {
+    fun save(authToken: AuthToken): AuthToken
+    fun deleteByAccountId(accountId: Long)
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.application.auth.port
+
+interface TokenProvider {
+    fun createAccessToken(accountId: Long): String
+    fun createRefreshToken(accountId: Long): String
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/result/AuthenticateResult.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/result/AuthenticateResult.kt
@@ -1,0 +1,7 @@
+package com.chat.chingudachi.application.auth.result
+
+data class AuthenticateResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val onboardingRequired: Boolean,
+)

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -24,4 +24,6 @@ enum class ErrorCode(
     // Auth
     AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Token has expired"),
     AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Invalid token"),
+    AUTH_OAUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "Invalid OAuth authorization code"),
+    AUTH_OAUTH_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "OAuth provider communication failed"),
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/RestClientConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/RestClientConfig.kt
@@ -2,10 +2,19 @@ package com.chat.chingudachi.infrastructure.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import java.time.Duration
 
 @Configuration
 class RestClientConfig {
     @Bean
-    fun restClient(): RestClient = RestClient.create()
+    fun restClient(): RestClient {
+        val factory = SimpleClientHttpRequestFactory()
+        factory.setConnectTimeout(Duration.ofSeconds(5))
+        factory.setReadTimeout(Duration.ofSeconds(10))
+        return RestClient.builder()
+            .requestFactory(factory)
+            .build()
+    }
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/RestClientConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/RestClientConfig.kt
@@ -1,0 +1,11 @@
+package com.chat.chingudachi.infrastructure.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+
+@Configuration
+class RestClientConfig {
+    @Bean
+    fun restClient(): RestClient = RestClient.create()
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
@@ -1,5 +1,6 @@
 package com.chat.chingudachi.infrastructure.jwt
 
+import com.chat.chingudachi.application.auth.port.TokenProvider
 import com.chat.chingudachi.domain.common.ErrorCode
 import com.chat.chingudachi.domain.common.UnauthorizedException
 import io.jsonwebtoken.ExpiredJwtException
@@ -7,24 +8,22 @@ import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 import java.util.Date
 import javax.crypto.SecretKey
 
 @Component
-@EnableConfigurationProperties(JwtProperties::class)
 class JwtProvider(
     private val jwtProperties: JwtProperties,
-) {
+) : TokenProvider {
     private val secretKey: SecretKey = Keys.hmacShaKeyFor(
         Decoders.BASE64.decode(jwtProperties.secret),
     )
 
-    fun createAccessToken(accountId: Long): String =
+    override fun createAccessToken(accountId: Long): String =
         createToken(accountId, jwtProperties.accessTokenExpiry.toMillis())
 
-    fun createRefreshToken(accountId: Long): String =
+    override fun createRefreshToken(accountId: Long): String =
         createToken(accountId, jwtProperties.refreshTokenExpiry.toMillis())
 
     fun validateToken(token: String): Boolean =

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClient.kt
@@ -8,7 +8,6 @@ import com.chat.chingudachi.domain.common.InternalServerException
 import com.chat.chingudachi.domain.common.UnauthorizedException
 import com.chat.chingudachi.infrastructure.oauth.dto.GoogleTokenResponse
 import com.chat.chingudachi.infrastructure.oauth.dto.GoogleUserInfoResponse
-import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
@@ -17,7 +16,6 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestClientException
 
 @Component
-@EnableConfigurationProperties(GoogleOAuthProperties::class)
 class GoogleOAuthClient(
     private val restClient: RestClient,
     private val properties: GoogleOAuthProperties,

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClient.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClient.kt
@@ -1,0 +1,69 @@
+package com.chat.chingudachi.infrastructure.oauth
+
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.InternalServerException
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import com.chat.chingudachi.infrastructure.oauth.dto.GoogleTokenResponse
+import com.chat.chingudachi.infrastructure.oauth.dto.GoogleUserInfoResponse
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.RestClientException
+
+@Component
+@EnableConfigurationProperties(GoogleOAuthProperties::class)
+class GoogleOAuthClient(
+    private val restClient: RestClient,
+    private val properties: GoogleOAuthProperties,
+) : OAuthClient {
+    override fun authenticate(code: String): OAuthUserInfo {
+        val tokenResponse = exchangeToken(code)
+        val userInfo = fetchUserInfo(tokenResponse.accessToken)
+        return OAuthUserInfo(
+            provider = OAuthProvider.GOOGLE,
+            providerUserId = userInfo.sub,
+            email = userInfo.email,
+        )
+    }
+
+    private fun exchangeToken(code: String): GoogleTokenResponse {
+        val formData = LinkedMultiValueMap<String, String>().apply {
+            add("code", code)
+            add("client_id", properties.clientId)
+            add("client_secret", properties.clientSecret)
+            add("redirect_uri", properties.redirectUri)
+            add("grant_type", "authorization_code")
+        }
+
+        try {
+            return restClient.post()
+                .uri(properties.tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formData)
+                .retrieve()
+                .body(GoogleTokenResponse::class.java)
+                ?: throw UnauthorizedException(ErrorCode.AUTH_OAUTH_CODE_INVALID)
+        } catch (e: RestClientException) {
+            throw UnauthorizedException(ErrorCode.AUTH_OAUTH_CODE_INVALID, e)
+        }
+    }
+
+    private fun fetchUserInfo(accessToken: String): GoogleUserInfoResponse {
+        try {
+            return restClient.get()
+                .uri(properties.userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+                .retrieve()
+                .body(GoogleUserInfoResponse::class.java)
+                ?: throw InternalServerException(ErrorCode.AUTH_OAUTH_PROVIDER_ERROR)
+        } catch (e: RestClientException) {
+            throw InternalServerException(ErrorCode.AUTH_OAUTH_PROVIDER_ERROR, e)
+        }
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthProperties.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthProperties.kt
@@ -1,0 +1,12 @@
+package com.chat.chingudachi.infrastructure.oauth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth.google")
+data class GoogleOAuthProperties(
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val tokenUri: String = "https://oauth2.googleapis.com/token",
+    val userInfoUri: String = "https://www.googleapis.com/oauth2/v3/userinfo",
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/dto/GoogleTokenResponse.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/dto/GoogleTokenResponse.kt
@@ -1,0 +1,12 @@
+package com.chat.chingudachi.infrastructure.oauth.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class GoogleTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+    @JsonProperty("token_type")
+    val tokenType: String,
+    @JsonProperty("expires_in")
+    val expiresIn: Int,
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/dto/GoogleUserInfoResponse.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/oauth/dto/GoogleUserInfoResponse.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.infrastructure.oauth.dto
+
+data class GoogleUserInfoResponse(
+    val sub: String,
+    val email: String,
+)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
@@ -1,0 +1,42 @@
+package com.chat.chingudachi.infrastructure.persistence
+
+import com.chat.chingudachi.application.auth.port.AccountCredentialStore
+import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.application.auth.port.AuthTokenStore
+import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.account.AccountCredential
+import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.auth.AuthToken
+import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class AccountStoreAdapter(
+    private val accountRepository: AccountRepository,
+) : AccountStore {
+    override fun save(account: Account): Account = accountRepository.save(account)
+}
+
+@Repository
+class AccountCredentialStoreAdapter(
+    private val accountCredentialRepository: AccountCredentialRepository,
+) : AccountCredentialStore {
+    override fun save(credential: AccountCredential): AccountCredential =
+        accountCredentialRepository.save(credential)
+
+    override fun findByCredentialTypeAndOauthKey(
+        credentialType: CredentialType,
+        oauthKey: String,
+    ): AccountCredential? =
+        accountCredentialRepository.findByCredentialTypeAndOauthKey(credentialType, oauthKey)
+}
+
+@Repository
+class AuthTokenStoreAdapter(
+    private val authTokenRepository: AuthTokenRepository,
+) : AuthTokenStore {
+    override fun save(authToken: AuthToken): AuthToken = authTokenRepository.save(authToken)
+    override fun deleteByAccountId(accountId: Long) = authTokenRepository.deleteByAccountId(accountId)
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountCredentialRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountCredentialRepository.kt
@@ -1,0 +1,9 @@
+package com.chat.chingudachi.infrastructure.persistence.account
+
+import com.chat.chingudachi.domain.account.AccountCredential
+import com.chat.chingudachi.domain.account.CredentialType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccountCredentialRepository : JpaRepository<AccountCredential, Long> {
+    fun findByCredentialTypeAndOauthKey(credentialType: CredentialType, oauthKey: String): AccountCredential?
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -22,3 +22,9 @@ jwt:
   secret: "Y2hpbmd1ZGFjaGktand0LXNlY3JldC1rZXktZm9yLWxvY2FsLWRldi0yNTZiaXQ"
   access-token-expiry: 1h
   refresh-token-expiry: 30d
+
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID:your-client-id}
+    client-secret: ${GOOGLE_CLIENT_SECRET:your-client-secret}
+    redirect-uri: "http://localhost:3000/auth/callback"

--- a/src/test/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCaseTest.kt
@@ -1,0 +1,189 @@
+package com.chat.chingudachi.application.auth
+
+import com.chat.chingudachi.application.auth.command.AuthenticateCommand
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.domain.account.AccountStatus
+import com.chat.chingudachi.domain.account.AccountType
+import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.account.Nation
+import com.chat.chingudachi.domain.account.NativeLanguage
+import com.chat.chingudachi.domain.account.Nickname
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import com.chat.chingudachi.fixture.AccountFixture
+import com.chat.chingudachi.fixture.OAuthUserInfoFixture
+import com.chat.chingudachi.infrastructure.jwt.JwtProvider
+import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDate
+
+class AuthenticateUseCaseTest : DescribeSpec() {
+    private val oAuthClient = mockk<OAuthClient>()
+    private val accountRepository = mockk<AccountRepository>(relaxUnitFun = true)
+    private val accountCredentialRepository = mockk<AccountCredentialRepository>(relaxUnitFun = true)
+    private val authTokenRepository = mockk<AuthTokenRepository>(relaxUnitFun = true)
+    private val jwtProvider = mockk<JwtProvider>()
+
+    private val useCase = AuthenticateUseCase(
+        oAuthClient = oAuthClient,
+        accountRepository = accountRepository,
+        accountCredentialRepository = accountCredentialRepository,
+        authTokenRepository = authTokenRepository,
+        jwtProvider = jwtProvider,
+    )
+
+    init {
+        beforeEach {
+            clearMocks(oAuthClient, accountRepository, accountCredentialRepository, authTokenRepository, jwtProvider)
+        }
+
+        describe("authenticate") {
+            val command = AuthenticateCommand(code = "valid-auth-code")
+            val oAuthUserInfo = OAuthUserInfoFixture.create()
+
+            context("신규 유저인 경우") {
+                it("Account + Credential을 생성하고, NOT_CONSENT 상태, onboardingRequired=true를 반환한다") {
+                    every { oAuthClient.authenticate("valid-auth-code") } returns oAuthUserInfo
+                    every {
+                        accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                            CredentialType.GOOGLE_OAUTH,
+                            oAuthUserInfo.providerUserId,
+                        )
+                    } returns null
+                    val savedAccountSlot = slot<com.chat.chingudachi.domain.account.Account>()
+                    every { accountRepository.save(capture(savedAccountSlot)) } answers { savedAccountSlot.captured }
+                    every { accountCredentialRepository.save(any()) } answers { firstArg() }
+                    every { jwtProvider.createAccessToken(any()) } returns "access-token"
+                    every { jwtProvider.createRefreshToken(any()) } returns "refresh-token"
+                    every { authTokenRepository.save(any()) } answers { firstArg() }
+
+                    val result = useCase.authenticate(command)
+
+                    result.accessToken shouldBe "access-token"
+                    result.refreshToken shouldBe "refresh-token"
+                    result.onboardingRequired shouldBe true
+
+                    savedAccountSlot.captured.accountStatus shouldBe AccountStatus.NOT_CONSENT
+                    savedAccountSlot.captured.accountType shouldBe AccountType.USER
+                    savedAccountSlot.captured.email shouldBe oAuthUserInfo.email
+
+                    verify { authTokenRepository.deleteByAccountId(any()) }
+                    verify { authTokenRepository.save(any()) }
+                }
+            }
+
+            context("기존 유저인 경우") {
+                it("기존 Account를 사용하고 새 Account를 생성하지 않는다") {
+                    val existingAccount = AccountFixture.create(id = 10L)
+                    val existingCredential = com.chat.chingudachi.domain.account.AccountCredential(
+                        id = 1L,
+                        account = existingAccount,
+                        credentialType = CredentialType.GOOGLE_OAUTH,
+                        oauthKey = oAuthUserInfo.providerUserId,
+                    )
+
+                    every { oAuthClient.authenticate("valid-auth-code") } returns oAuthUserInfo
+                    every {
+                        accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                            CredentialType.GOOGLE_OAUTH,
+                            oAuthUserInfo.providerUserId,
+                        )
+                    } returns existingCredential
+                    every { jwtProvider.createAccessToken(10L) } returns "existing-access"
+                    every { jwtProvider.createRefreshToken(10L) } returns "existing-refresh"
+                    every { authTokenRepository.save(any()) } answers { firstArg() }
+
+                    val result = useCase.authenticate(command)
+
+                    result.accessToken shouldBe "existing-access"
+                    result.refreshToken shouldBe "existing-refresh"
+                    result.onboardingRequired shouldBe true
+
+                    verify(exactly = 0) { accountRepository.save(any()) }
+                    verify { authTokenRepository.deleteByAccountId(10L) }
+                }
+            }
+
+            context("온보딩 완료 유저인 경우") {
+                it("onboardingRequired=false를 반환한다") {
+                    val completedAccount = AccountFixture.create(
+                        id = 20L,
+                        accountStatus = AccountStatus.ACTIVE,
+                        nickname = Nickname("테스트유저"),
+                        birthDate = LocalDate.of(1995, 5, 15),
+                        nation = Nation.KR,
+                        nativeLanguage = NativeLanguage.KO,
+                    )
+                    val existingCredential = com.chat.chingudachi.domain.account.AccountCredential(
+                        id = 2L,
+                        account = completedAccount,
+                        credentialType = CredentialType.GOOGLE_OAUTH,
+                        oauthKey = oAuthUserInfo.providerUserId,
+                    )
+
+                    every { oAuthClient.authenticate("valid-auth-code") } returns oAuthUserInfo
+                    every {
+                        accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                            CredentialType.GOOGLE_OAUTH,
+                            oAuthUserInfo.providerUserId,
+                        )
+                    } returns existingCredential
+                    every { jwtProvider.createAccessToken(20L) } returns "completed-access"
+                    every { jwtProvider.createRefreshToken(20L) } returns "completed-refresh"
+                    every { authTokenRepository.save(any()) } answers { firstArg() }
+
+                    val result = useCase.authenticate(command)
+
+                    result.onboardingRequired shouldBe false
+                }
+            }
+
+            context("기존 refresh token이 있는 경우") {
+                it("기존 토큰을 삭제하고 새로 생성한다") {
+                    val existingAccount = AccountFixture.create(id = 30L)
+                    val existingCredential = com.chat.chingudachi.domain.account.AccountCredential(
+                        id = 3L,
+                        account = existingAccount,
+                        credentialType = CredentialType.GOOGLE_OAUTH,
+                        oauthKey = oAuthUserInfo.providerUserId,
+                    )
+
+                    every { oAuthClient.authenticate("valid-auth-code") } returns oAuthUserInfo
+                    every {
+                        accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                            CredentialType.GOOGLE_OAUTH,
+                            oAuthUserInfo.providerUserId,
+                        )
+                    } returns existingCredential
+                    every { jwtProvider.createAccessToken(30L) } returns "new-access"
+                    every { jwtProvider.createRefreshToken(30L) } returns "new-refresh"
+                    every { authTokenRepository.save(any()) } answers { firstArg() }
+
+                    useCase.authenticate(command)
+
+                    verify(exactly = 1) { authTokenRepository.deleteByAccountId(30L) }
+                    verify(exactly = 1) { authTokenRepository.save(any()) }
+                }
+            }
+
+            context("OAuth 인증 실패 시") {
+                it("예외를 전파한다") {
+                    every { oAuthClient.authenticate("invalid-code") } throws
+                        UnauthorizedException()
+
+                    shouldThrow<UnauthorizedException> {
+                        useCase.authenticate(AuthenticateCommand(code = "invalid-code"))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/fixture/AccountCredentialFixture.kt
+++ b/src/test/kotlin/com/chat/chingudachi/fixture/AccountCredentialFixture.kt
@@ -1,0 +1,20 @@
+package com.chat.chingudachi.fixture
+
+import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.account.AccountCredential
+import com.chat.chingudachi.domain.account.CredentialType
+
+object AccountCredentialFixture {
+    fun create(
+        id: Long = 0L,
+        account: Account = AccountFixture.create(id = 0L),
+        credentialType: CredentialType = CredentialType.GOOGLE_OAUTH,
+        oauthKey: String = "google-oauth-key-123",
+    ): AccountCredential =
+        AccountCredential(
+            id = id,
+            account = account,
+            credentialType = credentialType,
+            oauthKey = oauthKey,
+        )
+}

--- a/src/test/kotlin/com/chat/chingudachi/fixture/OAuthUserInfoFixture.kt
+++ b/src/test/kotlin/com/chat/chingudachi/fixture/OAuthUserInfoFixture.kt
@@ -1,0 +1,17 @@
+package com.chat.chingudachi.fixture
+
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+
+object OAuthUserInfoFixture {
+    fun create(
+        provider: OAuthProvider = OAuthProvider.GOOGLE,
+        providerUserId: String = "google-user-id-123",
+        email: String = "test@gmail.com",
+    ): OAuthUserInfo =
+        OAuthUserInfo(
+            provider = provider,
+            providerUserId = providerUserId,
+            email = email,
+        )
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClientTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/oauth/GoogleOAuthClientTest.kt
@@ -1,0 +1,105 @@
+package com.chat.chingudachi.infrastructure.oauth
+
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.InternalServerException
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest
+import org.springframework.test.web.client.response.MockRestResponseCreators.withServerError
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestClient
+
+class GoogleOAuthClientTest : DescribeSpec() {
+    private val builder = RestClient.builder()
+    private val mockServer = MockRestServiceServer.bindTo(builder).build()
+    private val restClient = builder.build()
+
+    private val properties = GoogleOAuthProperties(
+        clientId = "test-client-id",
+        clientSecret = "test-client-secret",
+        redirectUri = "http://localhost:3000/callback",
+    )
+
+    private val googleOAuthClient = GoogleOAuthClient(restClient, properties)
+
+    init {
+        afterEach { mockServer.reset() }
+
+        describe("authenticate") {
+            context("정상 흐름") {
+                it("code → token 교환 → userInfo 조회 → OAuthUserInfo를 반환한다") {
+                    mockServer.expect(requestTo(properties.tokenUri))
+                        .andExpect(method(HttpMethod.POST))
+                        .andRespond(
+                            withSuccess(
+                                """{"access_token":"google-access-token","token_type":"Bearer","expires_in":3600}""",
+                                MediaType.APPLICATION_JSON,
+                            ),
+                        )
+
+                    mockServer.expect(requestTo(properties.userInfoUri))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(
+                            withSuccess(
+                                """{"sub":"google-user-123","email":"test@gmail.com"}""",
+                                MediaType.APPLICATION_JSON,
+                            ),
+                        )
+
+                    val result = googleOAuthClient.authenticate("valid-code")
+
+                    result.provider shouldBe OAuthProvider.GOOGLE
+                    result.providerUserId shouldBe "google-user-123"
+                    result.email shouldBe "test@gmail.com"
+
+                    mockServer.verify()
+                }
+            }
+
+            context("토큰 교환 실패 시") {
+                it("AUTH_OAUTH_CODE_INVALID 예외를 던진다") {
+                    mockServer.expect(requestTo(properties.tokenUri))
+                        .andExpect(method(HttpMethod.POST))
+                        .andRespond(withBadRequest())
+
+                    val exception = shouldThrow<UnauthorizedException> {
+                        googleOAuthClient.authenticate("invalid-code")
+                    }
+
+                    exception.errorCode shouldBe ErrorCode.AUTH_OAUTH_CODE_INVALID
+                }
+            }
+
+            context("userInfo 조회 실패 시") {
+                it("AUTH_OAUTH_PROVIDER_ERROR 예외를 던진다") {
+                    mockServer.expect(requestTo(properties.tokenUri))
+                        .andExpect(method(HttpMethod.POST))
+                        .andRespond(
+                            withSuccess(
+                                """{"access_token":"google-access-token","token_type":"Bearer","expires_in":3600}""",
+                                MediaType.APPLICATION_JSON,
+                            ),
+                        )
+
+                    mockServer.expect(requestTo(properties.userInfoUri))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withServerError())
+
+                    val exception = shouldThrow<InternalServerException> {
+                        googleOAuthClient.authenticate("valid-code")
+                    }
+
+                    exception.errorCode shouldBe ErrorCode.AUTH_OAUTH_PROVIDER_ERROR
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountCredentialRepositoryTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountCredentialRepositoryTest.kt
@@ -1,0 +1,100 @@
+package com.chat.chingudachi.infrastructure.persistence.account
+
+import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.fixture.AccountCredentialFixture
+import com.chat.chingudachi.fixture.AccountFixture
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import jakarta.persistence.EntityManager
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@ActiveProfiles("test")
+@AutoConfigureEmbeddedDatabase
+class AccountCredentialRepositoryTest(
+    private val accountCredentialRepository: AccountCredentialRepository,
+    private val accountRepository: AccountRepository,
+    private val entityManager: EntityManager,
+) : DescribeSpec() {
+    init {
+        describe("AccountCredential 영속성") {
+            it("AccountCredential을 저장하고 조회할 수 있다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                val credential = AccountCredentialFixture.create(
+                    account = account,
+                    oauthKey = "google-user-id-123",
+                )
+
+                val saved = accountCredentialRepository.saveAndFlush(credential)
+                entityManager.clear()
+
+                val found = accountCredentialRepository.findById(saved.id).get()
+                found.credentialType shouldBe CredentialType.GOOGLE_OAUTH
+                found.oauthKey shouldBe "google-user-id-123"
+                found.account.id shouldBe account.id
+            }
+        }
+
+        describe("findByCredentialTypeAndOauthKey") {
+            it("credentialType과 oauthKey로 조회할 수 있다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                accountCredentialRepository.saveAndFlush(
+                    AccountCredentialFixture.create(
+                        account = account,
+                        credentialType = CredentialType.GOOGLE_OAUTH,
+                        oauthKey = "google-user-id-456",
+                    ),
+                )
+                entityManager.clear()
+
+                val found = accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                    credentialType = CredentialType.GOOGLE_OAUTH,
+                    oauthKey = "google-user-id-456",
+                )
+
+                found.shouldNotBeNull()
+                found.account.id shouldBe account.id
+            }
+
+            it("존재하지 않는 oauthKey이면 null을 반환한다") {
+                val found = accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                    credentialType = CredentialType.GOOGLE_OAUTH,
+                    oauthKey = "non-existent-key",
+                )
+
+                found.shouldBeNull()
+            }
+
+            it("다른 credentialType이면 null을 반환한다") {
+                val account = accountRepository.saveAndFlush(
+                    AccountFixture.create(id = 0),
+                )
+                accountCredentialRepository.saveAndFlush(
+                    AccountCredentialFixture.create(
+                        account = account,
+                        credentialType = CredentialType.GOOGLE_OAUTH,
+                        oauthKey = "google-user-id-789",
+                    ),
+                )
+                entityManager.clear()
+
+                // CredentialType이 하나뿐이라 직접 다른 타입 테스트는 불가하지만,
+                // 같은 타입 + 다른 키로 null 반환 확인
+                val found = accountCredentialRepository.findByCredentialTypeAndOauthKey(
+                    credentialType = CredentialType.GOOGLE_OAUTH,
+                    oauthKey = "different-key",
+                )
+
+                found.shouldBeNull()
+            }
+        }
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -14,3 +14,9 @@ jwt:
   secret: "dGVzdC1qd3Qtc2VjcmV0LWtleS1mb3ItdGVzdGluZy1vbmx5LTI1NmJpdHM="
   access-token-expiry: 10s
   refresh-token-expiry: 1m
+
+oauth:
+  google:
+    client-id: test-client-id
+    client-secret: test-client-secret
+    redirect-uri: "http://localhost:3000/auth/callback"


### PR DESCRIPTION
## Summary
- Google OAuth 2.0 인증 흐름 핵심 비즈니스 로직 구현
- 프로젝트 최초의 UseCase(application layer)로 Clean Architecture 핵심 계층 완성
- OAuthClient 포트 인터페이스로 DIP 준수

## Changes
- `AuthenticateUseCase` — code → Google 인증 → 계정 자동 생성/조회 → JWT 발급
- `OAuthClient` 포트 인터페이스 + `GoogleOAuthClient` 구현체 (RestClient)
- `AccountCredentialRepository` — credential 조회 쿼리
- `ErrorCode` — `AUTH_OAUTH_CODE_INVALID`, `AUTH_OAUTH_PROVIDER_ERROR` 추가
- `RestClientConfig` — RestClient 빈 등록
- 설정 파일에 `oauth.google` 섹션 추가 (client-id/secret 환경변수 기반)
- 테스트 11개 (UseCase 5 + GoogleOAuthClient 3 + Repository 3)

## Notes
- 단일 디바이스 정책: 로그인 시 기존 refresh token 전체 삭제 (MVP)
- 신규 유저는 `NOT_CONSENT` 상태로 생성 (약관 동의 → 온보딩 순서)
- Presentation layer (Controller)는 BE-06에서 구현 예정

Closes #6