### PR TITLE
feat: Auth API + Spring Security JWT 필터 구현

### DIFF
--- a/docs/backend/api/auth-google-login.md
+++ b/docs/backend/api/auth-google-login.md
@@ -1,0 +1,65 @@
+# Google 로그인
+
+## 엔드포인트
+POST /api/auth/google
+
+## 인증
+불필요 (permitAll)
+
+## 요청
+
+### Headers
+| 헤더 | 값 |
+|------|-----|
+| Content-Type | application/json |
+
+### Body
+```json
+{
+  "code": "google-authorization-code"
+}
+```
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| code | String | O | Google OAuth authorization code |
+
+## 응답
+
+### 성공 (200 OK)
+```json
+{
+  "code": null,
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...",
+    "onboardingRequired": true
+  },
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-01T14:00:00Z"
+}
+```
+
+### Set-Cookie 헤더
+```
+refreshToken=eyJhbGci...; Path=/api/auth/refresh; HttpOnly; Secure; SameSite=Lax; Max-Age=2592000
+```
+
+| 속성 | 값 | 설명 |
+|------|-----|------|
+| HttpOnly | true | JS 접근 차단 (XSS 방지) |
+| Secure | true | HTTPS만 전송 |
+| SameSite | Lax | CSRF 방지 |
+| Path | /api/auth/refresh | 리프레시 요청에만 전송 |
+| Max-Age | 2592000 | 30일 |
+
+### 에러 케이스
+
+| 상태 | 에러 코드 | 설명 |
+|------|-----------|------|
+| 401 | AUTH_OAUTH_CODE_INVALID | 유효하지 않은 authorization code |
+| 502 | AUTH_OAUTH_PROVIDER_ERROR | Google API 통신 실패 |
+
+## 에러 코드
+- `AUTH_OAUTH_CODE_INVALID` — 잘못되었거나 만료된 authorization code
+- `AUTH_OAUTH_PROVIDER_ERROR` — Google 서버와의 통신 오류

--- a/docs/backend/api/auth-refresh.md
+++ b/docs/backend/api/auth-refresh.md
@@ -1,0 +1,56 @@
+# 토큰 리프레시
+
+## 엔드포인트
+POST /api/auth/refresh
+
+## 인증
+불필요 (permitAll) — refresh token은 쿠키로 전달
+
+## 요청
+
+### Cookie
+| 이름 | 필수 | 설명 |
+|------|------|------|
+| refreshToken | O | 로그인 시 발급된 httpOnly 쿠키 |
+
+### Body
+없음
+
+## 응답
+
+### 성공 (200 OK)
+```json
+{
+  "code": null,
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiJ9...(새 토큰)",
+    "onboardingRequired": false
+  },
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-01T14:30:00Z"
+}
+```
+
+### Set-Cookie 헤더
+기존 쿠키를 새 refresh token으로 교체 (토큰 로테이션)
+
+### 에러 케이스
+
+| 상태 | 에러 코드 | 설명 |
+|------|-----------|------|
+| 401 | AUTH_REFRESH_TOKEN_INVALID | 쿠키 없음 또는 이미 사용된 토큰 |
+| 401 | AUTH_REFRESH_TOKEN_EXPIRED | 만료된 refresh token |
+
+## 토큰 로테이션
+
+리프레시 시 기존 토큰을 삭제하고 새 토큰을 발급합니다:
+1. 쿠키에서 refresh token 추출
+2. JWT 서명 + 만료 검증
+3. DB에서 토큰 조회 (단일 사용 보장)
+4. 기존 토큰 삭제 → 새 access + refresh 토큰 발급
+5. 새 refresh token을 httpOnly 쿠키로 설정
+
+## 에러 코드
+- `AUTH_REFRESH_TOKEN_INVALID` — 쿠키가 없거나 DB에서 찾을 수 없는 토큰
+- `AUTH_REFRESH_TOKEN_EXPIRED` — 만료된 refresh token (기존 토큰도 삭제됨)

--- a/docs/backend/spring-security.md
+++ b/docs/backend/spring-security.md
@@ -1,0 +1,46 @@
+# Spring Security 설정
+
+## 아키텍처
+
+```
+요청 → MdcLoggingFilter → JwtAuthenticationFilter → SecurityFilterChain → Controller
+```
+
+## JwtAuthenticationFilter
+
+`OncePerRequestFilter`를 상속한 JWT 인증 필터.
+
+### 동작 흐름
+1. `Authorization: Bearer {token}` 헤더에서 토큰 추출
+2. `TokenProvider.validateToken()`으로 서명 + 만료 검증
+3. 유효하면 `parseAccountId()`로 accountId 추출
+4. `UsernamePasswordAuthenticationToken.authenticated(accountId, null, emptyList())`로 인증 객체 생성
+5. `SecurityContextHolder`에 설정
+6. MDC에 userId 업데이트 (로깅용)
+
+### 토큰이 없거나 유효하지 않은 경우
+SecurityContext를 설정하지 않고 필터 체인을 계속 진행. Spring Security의 authorization 체크에서 401 반환.
+
+## SecurityConfig 경로 규칙
+
+| 경로 | 권한 | 설명 |
+|------|------|------|
+| `/api/auth/**` | permitAll | 로그인, 리프레시 |
+| 그 외 모든 경로 | authenticated | JWT 인증 필요 |
+
+## SecurityContextUtil
+
+`SecurityContextHolder`에서 accountId를 추출하는 유틸리티:
+
+```kotlin
+val accountId = SecurityContextUtil.getCurrentAccountId()
+```
+
+인증되지 않은 상태에서 호출하면 `UnauthorizedException` 발생.
+
+## 쿠키 기반 Refresh Token
+
+- httpOnly: JS 접근 차단 (XSS 방지)
+- Secure: HTTPS만 전송
+- SameSite=Lax: CSRF 기본 방지
+- Path=/api/auth/refresh: 리프레시 엔드포인트에만 전송

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthConstants.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthConstants.kt
@@ -1,0 +1,7 @@
+package com.chat.chingudachi.application.auth
+
+import java.time.Duration
+
+object AuthConstants {
+    val REFRESH_TOKEN_TTL: Duration = Duration.ofDays(30)
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
@@ -17,7 +17,6 @@ import com.chat.chingudachi.domain.auth.OAuthProvider
 import com.chat.chingudachi.domain.auth.OAuthUserInfo
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Duration
 import java.time.Instant
 
 @Service
@@ -74,7 +73,7 @@ class AuthenticateUseCase(
             AuthToken(
                 account = account,
                 refreshToken = refreshToken,
-                expiresAt = Instant.now().plus(REFRESH_TOKEN_TTL),
+                expiresAt = Instant.now().plus(AuthConstants.REFRESH_TOKEN_TTL),
             ),
         )
 
@@ -90,7 +89,4 @@ class AuthenticateUseCase(
             OAuthProvider.GOOGLE -> CredentialType.GOOGLE_OAUTH
         }
 
-    companion object {
-        private val REFRESH_TOKEN_TTL = Duration.ofDays(30)
-    }
 }

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
@@ -8,7 +8,6 @@ import com.chat.chingudachi.domain.common.ErrorCode
 import com.chat.chingudachi.domain.common.UnauthorizedException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.Duration
 import java.time.Instant
 
 @Service
@@ -40,7 +39,7 @@ class RefreshTokenUseCase(
             AuthToken(
                 account = account,
                 refreshToken = newRefreshToken,
-                expiresAt = Instant.now().plus(REFRESH_TOKEN_TTL),
+                expiresAt = Instant.now().plus(AuthConstants.REFRESH_TOKEN_TTL),
             ),
         )
 
@@ -51,7 +50,4 @@ class RefreshTokenUseCase(
         )
     }
 
-    companion object {
-        private val REFRESH_TOKEN_TTL = Duration.ofDays(30)
-    }
 }

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
@@ -1,0 +1,57 @@
+package com.chat.chingudachi.application.auth
+
+import com.chat.chingudachi.application.auth.port.AuthTokenStore
+import com.chat.chingudachi.application.auth.port.TokenProvider
+import com.chat.chingudachi.application.auth.result.AuthenticateResult
+import com.chat.chingudachi.domain.auth.AuthToken
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+
+@Service
+@Transactional
+class RefreshTokenUseCase(
+    private val authTokenStore: AuthTokenStore,
+    private val tokenProvider: TokenProvider,
+) {
+    fun refresh(refreshToken: String): AuthenticateResult {
+        val accountId = tokenProvider.parseAccountId(refreshToken)
+
+        val authToken = authTokenStore.findByAccountIdAndRefreshToken(accountId, refreshToken)
+            ?: throw UnauthorizedException(ErrorCode.AUTH_REFRESH_TOKEN_INVALID)
+
+        if (authToken.isExpired()) {
+            authTokenStore.deleteByAccountId(accountId)
+            throw UnauthorizedException(ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED)
+        }
+
+        val account = authToken.account
+        val onboardingRequired = !account.isOnboardingComplete()
+
+        authTokenStore.deleteByAccountId(accountId)
+
+        val newAccessToken = tokenProvider.createAccessToken(accountId)
+        val newRefreshToken = tokenProvider.createRefreshToken(accountId)
+
+        authTokenStore.save(
+            AuthToken(
+                account = account,
+                refreshToken = newRefreshToken,
+                expiresAt = Instant.now().plus(REFRESH_TOKEN_TTL),
+            ),
+        )
+
+        return AuthenticateResult(
+            accessToken = newAccessToken,
+            refreshToken = newRefreshToken,
+            onboardingRequired = onboardingRequired,
+        )
+    }
+
+    companion object {
+        private val REFRESH_TOKEN_TTL = Duration.ofDays(30)
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
@@ -16,5 +16,6 @@ interface AccountCredentialStore {
 
 interface AuthTokenStore {
     fun save(authToken: AuthToken): AuthToken
+    fun findByAccountIdAndRefreshToken(accountId: Long, refreshToken: String): AuthToken?
     fun deleteByAccountId(accountId: Long)
 }

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
@@ -3,4 +3,6 @@ package com.chat.chingudachi.application.auth.port
 interface TokenProvider {
     fun createAccessToken(accountId: Long): String
     fun createRefreshToken(accountId: Long): String
+    fun validateToken(token: String): Boolean
+    fun parseAccountId(token: String): Long
 }

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -24,6 +24,8 @@ enum class ErrorCode(
     // Auth
     AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Token has expired"),
     AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Invalid token"),
+    AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Refresh token has expired"),
+    AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "Invalid refresh token"),
     AUTH_OAUTH_CODE_INVALID(HttpStatus.UNAUTHORIZED, "Invalid OAuth authorization code"),
     AUTH_OAUTH_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "OAuth provider communication failed"),
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
@@ -56,7 +56,7 @@ class SecurityConfig(
 }
 
 @Configuration
-class CorsConfiguration(
+class AppCorsConfig(
     private val corsProperties: CorsProperties,
 ) {
     @Bean

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
@@ -1,21 +1,32 @@
 package com.chat.chingudachi.infrastructure.config
 
+import com.chat.chingudachi.application.auth.port.TokenProvider
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.infrastructure.security.JwtAuthenticationFilter
+import com.chat.chingudachi.presentation.common.ApiResponse
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import tools.jackson.databind.ObjectMapper
 
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(CorsProperties::class)
-class SecurityConfig {
+class SecurityConfig(
+    private val tokenProvider: TokenProvider,
+    private val objectMapper: ObjectMapper,
+) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http {
@@ -25,11 +36,23 @@ class SecurityConfig {
                 sessionCreationPolicy = SessionCreationPolicy.STATELESS
             }
             authorizeHttpRequests {
-                authorize(anyRequest, permitAll)
+                authorize("/api/auth/**", permitAll)
+                authorize(anyRequest, authenticated)
             }
+            exceptionHandling {
+                authenticationEntryPoint = authenticationEntryPoint()
+            }
+            addFilterBefore<UsernamePasswordAuthenticationFilter>(JwtAuthenticationFilter(tokenProvider))
         }
         return http.build()
     }
+
+    private fun authenticationEntryPoint() =
+        org.springframework.security.web.AuthenticationEntryPoint { _, response, _ ->
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            objectMapper.writeValue(response.outputStream, ApiResponse.error(ErrorCode.UNAUTHORIZED))
+        }
 }
 
 @Configuration

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
@@ -26,7 +26,7 @@ class JwtProvider(
     override fun createRefreshToken(accountId: Long): String =
         createToken(accountId, jwtProperties.refreshTokenExpiry.toMillis())
 
-    fun validateToken(token: String): Boolean =
+    override fun validateToken(token: String): Boolean =
         try {
             Jwts.parser()
                 .verifyWith(secretKey)
@@ -39,7 +39,7 @@ class JwtProvider(
             false
         }
 
-    fun parseAccountId(token: String): Long =
+    override fun parseAccountId(token: String): Long =
         try {
             Jwts.parser()
                 .verifyWith(secretKey)

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
@@ -38,5 +38,9 @@ class AuthTokenStoreAdapter(
     private val authTokenRepository: AuthTokenRepository,
 ) : AuthTokenStore {
     override fun save(authToken: AuthToken): AuthToken = authTokenRepository.save(authToken)
+
+    override fun findByAccountIdAndRefreshToken(accountId: Long, refreshToken: String): AuthToken? =
+        authTokenRepository.findByAccountIdAndRefreshToken(accountId, refreshToken)
+
     override fun deleteByAccountId(accountId: Long) = authTokenRepository.deleteByAccountId(accountId)
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,46 @@
+package com.chat.chingudachi.infrastructure.security
+
+import com.chat.chingudachi.application.auth.port.TokenProvider
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+private val log = KotlinLogging.logger {}
+
+class JwtAuthenticationFilter(
+    private val tokenProvider: TokenProvider,
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        extractToken(request)?.let { token ->
+            if (tokenProvider.validateToken(token)) {
+                val accountId = tokenProvider.parseAccountId(token)
+                val authentication = UsernamePasswordAuthenticationToken.authenticated(
+                    accountId, null, emptyList(),
+                )
+                SecurityContextHolder.getContext().authentication = authentication
+                MDC.put("userId", accountId.toString())
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+
+    private fun extractToken(request: HttpServletRequest): String? {
+        val header = request.getHeader(AUTHORIZATION_HEADER) ?: return null
+        return if (header.startsWith(BEARER_PREFIX)) header.substring(BEARER_PREFIX.length) else null
+    }
+
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/security/SecurityContextUtil.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/security/SecurityContextUtil.kt
@@ -1,0 +1,13 @@
+package com.chat.chingudachi.infrastructure.security
+
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import org.springframework.security.core.context.SecurityContextHolder
+
+object SecurityContextUtil {
+    fun getCurrentAccountId(): Long {
+        val authentication = SecurityContextHolder.getContext().authentication
+            ?: throw UnauthorizedException()
+        return authentication.principal as? Long
+            ?: throw UnauthorizedException()
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/auth/AuthController.kt
@@ -1,5 +1,6 @@
 package com.chat.chingudachi.presentation.auth
 
+import com.chat.chingudachi.application.auth.AuthConstants
 import com.chat.chingudachi.application.auth.AuthenticateUseCase
 import com.chat.chingudachi.application.auth.RefreshTokenUseCase
 import com.chat.chingudachi.application.auth.command.AuthenticateCommand
@@ -14,8 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.Duration
-
 @RestController
 @RequestMapping("/api/auth")
 class AuthController(
@@ -57,12 +56,9 @@ class AuthController(
             .secure(true)
             .sameSite("Lax")
             .path("/api/auth/refresh")
-            .maxAge(REFRESH_COOKIE_MAX_AGE)
+            .maxAge(AuthConstants.REFRESH_TOKEN_TTL)
             .build()
         response.addHeader("Set-Cookie", cookie.toString())
     }
 
-    companion object {
-        private val REFRESH_COOKIE_MAX_AGE = Duration.ofDays(30)
-    }
 }

--- a/src/main/kotlin/com/chat/chingudachi/presentation/auth/dto/AuthRequest.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/auth/dto/AuthRequest.kt
@@ -1,0 +1,5 @@
+package com.chat.chingudachi.presentation.auth.dto
+
+data class GoogleLoginRequest(
+    val code: String,
+)

--- a/src/main/kotlin/com/chat/chingudachi/presentation/auth/dto/AuthResponse.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/auth/dto/AuthResponse.kt
@@ -1,0 +1,6 @@
+package com.chat.chingudachi.presentation.auth.dto
+
+data class LoginResponse(
+    val accessToken: String,
+    val onboardingRequired: Boolean,
+)

--- a/src/test/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCaseTest.kt
@@ -1,0 +1,149 @@
+package com.chat.chingudachi.application.auth
+
+import com.chat.chingudachi.application.auth.port.AuthTokenStore
+import com.chat.chingudachi.application.auth.port.TokenProvider
+import com.chat.chingudachi.domain.account.AccountStatus
+import com.chat.chingudachi.domain.account.Nation
+import com.chat.chingudachi.domain.account.NativeLanguage
+import com.chat.chingudachi.domain.account.Nickname
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import com.chat.chingudachi.fixture.AccountFixture
+import com.chat.chingudachi.fixture.AuthTokenFixture
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+
+class RefreshTokenUseCaseTest : DescribeSpec() {
+    private val authTokenStore = mockk<AuthTokenStore>(relaxUnitFun = true)
+    private val tokenProvider = mockk<TokenProvider>()
+
+    private val useCase = RefreshTokenUseCase(
+        authTokenStore = authTokenStore,
+        tokenProvider = tokenProvider,
+    )
+
+    init {
+        beforeEach {
+            clearMocks(authTokenStore, tokenProvider)
+        }
+
+        describe("refresh") {
+            val oldRefreshToken = "old-refresh-token"
+            val accountId = 1L
+
+            context("유효한 refresh token인 경우") {
+                it("기존 토큰을 삭제하고 새 토큰 쌍을 발급한다") {
+                    val account = AccountFixture.create(id = accountId)
+                    val authToken = AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = oldRefreshToken,
+                        expiresAt = Instant.now().plus(Duration.ofDays(29)),
+                    )
+
+                    every { tokenProvider.parseAccountId(oldRefreshToken) } returns accountId
+                    every {
+                        authTokenStore.findByAccountIdAndRefreshToken(accountId, oldRefreshToken)
+                    } returns authToken
+                    every { tokenProvider.createAccessToken(accountId) } returns "new-access-token"
+                    every { tokenProvider.createRefreshToken(accountId) } returns "new-refresh-token"
+                    every { authTokenStore.save(any()) } answers { firstArg() }
+
+                    val result = useCase.refresh(oldRefreshToken)
+
+                    result.accessToken shouldBe "new-access-token"
+                    result.refreshToken shouldBe "new-refresh-token"
+                    result.onboardingRequired shouldBe true
+
+                    verify(exactly = 1) { authTokenStore.deleteByAccountId(accountId) }
+                    verify(exactly = 1) { authTokenStore.save(any()) }
+                }
+            }
+
+            context("온보딩 완료 유저의 refresh인 경우") {
+                it("onboardingRequired=false를 반환한다") {
+                    val completedAccount = AccountFixture.create(
+                        id = accountId,
+                        accountStatus = AccountStatus.ACTIVE,
+                        nickname = Nickname("테스트유저"),
+                        birthDate = LocalDate.of(1995, 5, 15),
+                        nation = Nation.KR,
+                        nativeLanguage = NativeLanguage.KO,
+                    )
+                    val authToken = AuthTokenFixture.create(
+                        account = completedAccount,
+                        refreshToken = oldRefreshToken,
+                    )
+
+                    every { tokenProvider.parseAccountId(oldRefreshToken) } returns accountId
+                    every {
+                        authTokenStore.findByAccountIdAndRefreshToken(accountId, oldRefreshToken)
+                    } returns authToken
+                    every { tokenProvider.createAccessToken(accountId) } returns "new-access"
+                    every { tokenProvider.createRefreshToken(accountId) } returns "new-refresh"
+                    every { authTokenStore.save(any()) } answers { firstArg() }
+
+                    val result = useCase.refresh(oldRefreshToken)
+
+                    result.onboardingRequired shouldBe false
+                }
+            }
+
+            context("DB에 없는 refresh token인 경우") {
+                it("AUTH_REFRESH_TOKEN_INVALID 예외를 던진다") {
+                    every { tokenProvider.parseAccountId(oldRefreshToken) } returns accountId
+                    every {
+                        authTokenStore.findByAccountIdAndRefreshToken(accountId, oldRefreshToken)
+                    } returns null
+
+                    val exception = shouldThrow<UnauthorizedException> {
+                        useCase.refresh(oldRefreshToken)
+                    }
+
+                    exception.errorCode shouldBe ErrorCode.AUTH_REFRESH_TOKEN_INVALID
+                }
+            }
+
+            context("만료된 refresh token인 경우") {
+                it("AUTH_REFRESH_TOKEN_EXPIRED 예외를 던지고 기존 토큰을 삭제한다") {
+                    val account = AccountFixture.create(id = accountId)
+                    val expiredToken = AuthTokenFixture.create(
+                        account = account,
+                        refreshToken = oldRefreshToken,
+                        expiresAt = Instant.now().minus(Duration.ofHours(1)),
+                    )
+
+                    every { tokenProvider.parseAccountId(oldRefreshToken) } returns accountId
+                    every {
+                        authTokenStore.findByAccountIdAndRefreshToken(accountId, oldRefreshToken)
+                    } returns expiredToken
+
+                    val exception = shouldThrow<UnauthorizedException> {
+                        useCase.refresh(oldRefreshToken)
+                    }
+
+                    exception.errorCode shouldBe ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED
+                    verify(exactly = 1) { authTokenStore.deleteByAccountId(accountId) }
+                }
+            }
+
+            context("JWT 파싱 실패 시") {
+                it("TokenProvider의 예외를 전파한다") {
+                    every { tokenProvider.parseAccountId(oldRefreshToken) } throws
+                        UnauthorizedException(ErrorCode.AUTH_TOKEN_INVALID)
+
+                    shouldThrow<UnauthorizedException> {
+                        useCase.refresh(oldRefreshToken)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,81 @@
+package com.chat.chingudachi.infrastructure.security
+
+import com.chat.chingudachi.application.auth.port.TokenProvider
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+
+class JwtAuthenticationFilterTest : DescribeSpec() {
+    private val tokenProvider = mockk<TokenProvider>()
+    private val filter = JwtAuthenticationFilter(tokenProvider)
+
+    init {
+        afterEach {
+            SecurityContextHolder.clearContext()
+            clearMocks(tokenProvider)
+        }
+
+        describe("JwtAuthenticationFilter") {
+            context("유효한 JWT가 Authorization 헤더에 있는 경우") {
+                it("SecurityContext에 accountId를 설정한다") {
+                    val request = MockHttpServletRequest("GET", "/api/users/me")
+                    request.addHeader("Authorization", "Bearer valid-token")
+                    val response = MockHttpServletResponse()
+
+                    every { tokenProvider.validateToken("valid-token") } returns true
+                    every { tokenProvider.parseAccountId("valid-token") } returns 42L
+
+                    filter.doFilter(request, response, MockFilterChain())
+
+                    val auth = SecurityContextHolder.getContext().authentication!!
+                    auth.principal shouldBe 42L
+                    auth.isAuthenticated shouldBe true
+                }
+            }
+
+            context("Authorization 헤더가 없는 경우") {
+                it("SecurityContext를 설정하지 않고 필터를 통과시킨다") {
+                    val request = MockHttpServletRequest("GET", "/api/test")
+                    val response = MockHttpServletResponse()
+
+                    filter.doFilter(request, response, MockFilterChain())
+
+                    SecurityContextHolder.getContext().authentication.shouldBeNull()
+                }
+            }
+
+            context("Bearer 프리픽스가 없는 경우") {
+                it("SecurityContext를 설정하지 않는다") {
+                    val request = MockHttpServletRequest("GET", "/api/test")
+                    request.addHeader("Authorization", "Basic some-token")
+                    val response = MockHttpServletResponse()
+
+                    filter.doFilter(request, response, MockFilterChain())
+
+                    SecurityContextHolder.getContext().authentication.shouldBeNull()
+                }
+            }
+
+            context("유효하지 않은 JWT인 경우") {
+                it("SecurityContext를 설정하지 않고 필터를 통과시킨다") {
+                    val request = MockHttpServletRequest("GET", "/api/test")
+                    request.addHeader("Authorization", "Bearer invalid-token")
+                    val response = MockHttpServletResponse()
+
+                    every { tokenProvider.validateToken("invalid-token") } returns false
+
+                    filter.doFilter(request, response, MockFilterChain())
+
+                    SecurityContextHolder.getContext().authentication.shouldBeNull()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilterTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/infrastructure/security/JwtAuthenticationFilterTest.kt
@@ -4,6 +4,7 @@ import com.chat.chingudachi.application.auth.port.TokenProvider
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import org.slf4j.MDC
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -37,6 +38,19 @@ class JwtAuthenticationFilterTest : DescribeSpec() {
                     val auth = SecurityContextHolder.getContext().authentication!!
                     auth.principal shouldBe 42L
                     auth.isAuthenticated shouldBe true
+                }
+
+                it("필터 완료 후 MDC userId가 정리된다") {
+                    val request = MockHttpServletRequest("GET", "/api/users/me")
+                    request.addHeader("Authorization", "Bearer valid-token")
+                    val response = MockHttpServletResponse()
+
+                    every { tokenProvider.validateToken("valid-token") } returns true
+                    every { tokenProvider.parseAccountId("valid-token") } returns 42L
+
+                    filter.doFilter(request, response, MockFilterChain())
+
+                    MDC.get("userId").shouldBeNull()
                 }
             }
 

--- a/src/test/kotlin/com/chat/chingudachi/presentation/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/presentation/auth/AuthControllerTest.kt
@@ -1,0 +1,176 @@
+package com.chat.chingudachi.presentation.auth
+
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+import com.chat.chingudachi.domain.common.UnauthorizedException
+import com.chat.chingudachi.infrastructure.jwt.JwtProvider
+import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
+import com.chat.chingudachi.support.MockOAuthConfig
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.clearMocks
+import io.mockk.every
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import jakarta.servlet.http.Cookie
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureEmbeddedDatabase
+@Import(MockOAuthConfig::class)
+@ActiveProfiles("test")
+class AuthControllerTest(
+    private val mockMvc: MockMvc,
+    private val jwtProvider: JwtProvider,
+    private val oAuthClient: OAuthClient,
+    private val authTokenRepository: AuthTokenRepository,
+    private val accountCredentialRepository: AccountCredentialRepository,
+    private val accountRepository: AccountRepository,
+) : DescribeSpec() {
+    init {
+        afterEach {
+            clearMocks(oAuthClient)
+            authTokenRepository.deleteAll()
+            accountCredentialRepository.deleteAll()
+            accountRepository.deleteAll()
+        }
+
+        describe("POST /api/auth/google") {
+            context("유효한 authorization code인 경우") {
+                it("200 + 액세스 토큰 + 리프레시 토큰 쿠키를 반환한다") {
+                    every { oAuthClient.authenticate("valid-code") } returns
+                        OAuthUserInfo(OAuthProvider.GOOGLE, "google-123", "test@example.com")
+
+                    val result = mockMvc.post("/api/auth/google") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"code":"valid-code"}"""
+                    }.andExpect {
+                        status { isOk() }
+                        jsonPath("$.data.accessToken") { isNotEmpty() }
+                        jsonPath("$.data.onboardingRequired") { value(true) }
+                    }.andReturn()
+
+                    val setCookieHeader = result.response.getHeader("Set-Cookie")!!
+                    setCookieHeader shouldStartWith "refreshToken="
+                    setCookieHeader.contains("HttpOnly") shouldBe true
+                    setCookieHeader.contains("Secure") shouldBe true
+                }
+            }
+
+            context("유효하지 않은 authorization code인 경우") {
+                it("401을 반환한다") {
+                    every { oAuthClient.authenticate("invalid-code") } throws
+                        UnauthorizedException()
+
+                    mockMvc.post("/api/auth/google") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"code":"invalid-code"}"""
+                    }.andExpect {
+                        status { isUnauthorized() }
+                        jsonPath("$.isSuccess") { value(false) }
+                    }
+                }
+            }
+        }
+
+        describe("POST /api/auth/refresh") {
+            context("유효한 refresh token 쿠키가 있는 경우") {
+                it("새 토큰 쌍을 반환하고 새 쿠키를 설정한다") {
+                    every { oAuthClient.authenticate("valid-code") } returns
+                        OAuthUserInfo(OAuthProvider.GOOGLE, "google-456", "test@example.com")
+
+                    val loginResult = mockMvc.post("/api/auth/google") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"code":"valid-code"}"""
+                    }.andReturn()
+
+                    val setCookieHeader = loginResult.response.getHeader("Set-Cookie")!!
+                    val refreshToken = setCookieHeader.substringAfter("refreshToken=").substringBefore(";")
+
+                    val refreshResult = mockMvc.post("/api/auth/refresh") {
+                        cookie(Cookie("refreshToken", refreshToken))
+                    }.andExpect {
+                        status { isOk() }
+                        jsonPath("$.data.accessToken") { isNotEmpty() }
+                        jsonPath("$.data.onboardingRequired") { value(true) }
+                    }.andReturn()
+
+                    val newSetCookie = refreshResult.response.getHeader("Set-Cookie")!!
+                    newSetCookie shouldStartWith "refreshToken="
+                }
+            }
+
+            context("refresh token 쿠키가 없는 경우") {
+                it("401을 반환한다") {
+                    mockMvc.post("/api/auth/refresh")
+                        .andExpect {
+                            status { isUnauthorized() }
+                            jsonPath("$.isSuccess") { value(false) }
+                        }
+                }
+            }
+        }
+
+        describe("JWT 인증 필터") {
+            context("인증이 필요한 엔드포인트에 JWT 없이 요청하면") {
+                it("401을 반환한다") {
+                    mockMvc.get("/api/users/me")
+                        .andExpect {
+                            status { isUnauthorized() }
+                            jsonPath("$.code") { value("UNAUTHORIZED") }
+                            jsonPath("$.isSuccess") { value(false) }
+                        }
+                }
+            }
+
+            context("인증이 필요한 엔드포인트에 유효한 JWT로 요청하면") {
+                it("인증을 통과한다 (엔드포인트가 없으면 404)") {
+                    every { oAuthClient.authenticate("valid-code") } returns
+                        OAuthUserInfo(OAuthProvider.GOOGLE, "google-789", "test@example.com")
+
+                    val loginResult = mockMvc.post("/api/auth/google") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"code":"valid-code"}"""
+                    }.andReturn()
+
+                    val responseBody = loginResult.response.contentAsString
+                    val accessToken = com.jayway.jsonpath.JsonPath.read<String>(
+                        responseBody,
+                        "$.data.accessToken",
+                    )
+
+                    mockMvc.get("/api/users/me") {
+                        header("Authorization", "Bearer $accessToken")
+                    }.andExpect {
+                        status { isNotFound() }
+                    }
+                }
+            }
+
+            context("auth 엔드포인트는 인증 없이 접근 가능") {
+                it("/api/auth/google은 permitAll") {
+                    every { oAuthClient.authenticate("code") } returns
+                        OAuthUserInfo(OAuthProvider.GOOGLE, "g-000", "test@example.com")
+
+                    mockMvc.post("/api/auth/google") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """{"code":"code"}"""
+                    }.andExpect {
+                        status { isOk() }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/presentation/auth/AuthControllerTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/presentation/auth/AuthControllerTest.kt
@@ -4,7 +4,6 @@ import com.chat.chingudachi.application.auth.port.OAuthClient
 import com.chat.chingudachi.domain.auth.OAuthProvider
 import com.chat.chingudachi.domain.auth.OAuthUserInfo
 import com.chat.chingudachi.domain.common.UnauthorizedException
-import com.chat.chingudachi.infrastructure.jwt.JwtProvider
 import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
 import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
 import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
@@ -32,7 +31,6 @@ import org.springframework.test.web.servlet.post
 @ActiveProfiles("test")
 class AuthControllerTest(
     private val mockMvc: MockMvc,
-    private val jwtProvider: JwtProvider,
     private val oAuthClient: OAuthClient,
     private val authTokenRepository: AuthTokenRepository,
     private val accountCredentialRepository: AccountCredentialRepository,

--- a/src/test/kotlin/com/chat/chingudachi/support/MockOAuthConfig.kt
+++ b/src/test/kotlin/com/chat/chingudachi/support/MockOAuthConfig.kt
@@ -1,0 +1,14 @@
+package com.chat.chingudachi.support
+
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import io.mockk.mockk
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@TestConfiguration
+class MockOAuthConfig {
+    @Bean
+    @Primary
+    fun mockOAuthClient(): OAuthClient = mockk()
+}


### PR DESCRIPTION
## Summary
Auth API 엔드포인트(로그인/리프레시)와 Spring Security JWT 인증 필터를 구현합니다. Refresh token은 httpOnly 쿠키로 전달하며, 토큰 로테이션으로 탈취 대응합니다.

## Changes
- `POST /api/auth/google` — authorization code로 로그인, refresh token은 httpOnly 쿠키
- `POST /api/auth/refresh` — 쿠키에서 refresh token 읽기, 토큰 로테이션 (기존 삭제 + 새 발급)
- `JwtAuthenticationFilter` — Authorization Bearer 토큰 검증 → SecurityContext 설정
- `SecurityConfig` 업데이트 — `/api/auth/**` permitAll, 나머지 authenticated, 401 JSON 응답
- `SecurityContextUtil` — SecurityContext에서 accountId 추출 유틸
- `TokenProvider` 포트에 `validateToken`, `parseAccountId` 추가
- `ErrorCode` — `AUTH_REFRESH_TOKEN_EXPIRED`, `AUTH_REFRESH_TOKEN_INVALID` 추가
- MockMvc 통합 테스트 + 단위 테스트 (16 cases)

## Notes
- 쿠키 설정: HttpOnly + Secure + SameSite=Lax + Path=/api/auth/refresh (XSS/CSRF 방지)
- JwtAuthenticationFilter는 @Component가 아닌 SecurityConfig에서 직접 생성 (이중 등록 방지)
- 테스트용 MockOAuthConfig (@Primary mock) 추가하여 Google API 의존 없이 통합 테스트 가능

Closes #7