### PR TITLE
feat(user): 닉네임 중복 체크 API

### DIFF
--- a/docs/backend/api/check-nickname.md
+++ b/docs/backend/api/check-nickname.md
@@ -1,0 +1,57 @@
+# 닉네임 중복 체크
+
+## 엔드포인트
+GET /api/users/check-nickname
+
+## 인증
+필요 (JWT Bearer token)
+
+## 요청
+
+### Headers
+| 헤더 | 값 |
+|------|-----|
+| Authorization | Bearer {accessToken} |
+
+### Query Parameters
+| 파라미터 | 타입 | 필수 | 설명 |
+|----------|------|------|------|
+| nickname | String | Y | 중복 확인할 닉네임 |
+
+### 닉네임 규칙
+- 2~12자
+- 공백 포함 불가
+
+## 응답
+
+### 사용 가능 (200 OK)
+```json
+{
+  "code": null,
+  "data": {
+    "available": true
+  },
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-02T10:00:00Z"
+}
+```
+
+### 이미 사용 중 (200 OK)
+```json
+{
+  "code": null,
+  "data": {
+    "available": false
+  },
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-02T10:00:00Z"
+}
+```
+
+### 에러 케이스
+
+| 상태 | 에러 코드 | 설명 |
+|------|-----------|------|
+| 401 | UNAUTHORIZED | JWT 없음 또는 유효하지 않음 |

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
@@ -3,11 +3,12 @@ package com.chat.chingudachi.application.auth.port
 import com.chat.chingudachi.domain.account.Account
 import com.chat.chingudachi.domain.account.AccountCredential
 import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.account.Nickname
 import com.chat.chingudachi.domain.auth.AuthToken
 interface AccountStore {
     fun save(account: Account): Account
     fun findById(id: Long): Account?
-    fun existsByNickname(nickname: String): Boolean
+    fun existsByNickname(nickname: Nickname): Boolean
 }
 
 interface AccountCredentialStore {

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/PersistencePorts.kt
@@ -7,6 +7,7 @@ import com.chat.chingudachi.domain.auth.AuthToken
 interface AccountStore {
     fun save(account: Account): Account
     fun findById(id: Long): Account?
+    fun existsByNickname(nickname: String): Boolean
 }
 
 interface AccountCredentialStore {

--- a/src/main/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCase.kt
@@ -1,0 +1,11 @@
+package com.chat.chingudachi.application.user
+
+import com.chat.chingudachi.application.auth.port.AccountStore
+import org.springframework.stereotype.Service
+
+@Service
+class CheckNicknameUseCase(
+    private val accountStore: AccountStore,
+) {
+    fun execute(nickname: String): Boolean = !accountStore.existsByNickname(nickname)
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCase.kt
@@ -1,11 +1,12 @@
 package com.chat.chingudachi.application.user
 
 import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.domain.account.Nickname
 import org.springframework.stereotype.Service
 
 @Service
 class CheckNicknameUseCase(
     private val accountStore: AccountStore,
 ) {
-    fun execute(nickname: String): Boolean = !accountStore.existsByNickname(nickname)
+    fun execute(nickname: String): Boolean = !accountStore.existsByNickname(Nickname(nickname))
 }

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
@@ -26,7 +26,7 @@ class Account(
     var accountStatus: AccountStatus,
     @Column(length = 255)
     var email: String? = null,
-    @Column(length = 20)
+    @Column(length = 20, unique = true)
     var nickname: Nickname? = null,
     @Column(name = "birth_date")
     var birthDate: LocalDate? = null,

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
@@ -6,6 +6,7 @@ import com.chat.chingudachi.application.auth.port.AuthTokenStore
 import com.chat.chingudachi.domain.account.Account
 import com.chat.chingudachi.domain.account.AccountCredential
 import com.chat.chingudachi.domain.account.CredentialType
+import com.chat.chingudachi.domain.account.Nickname
 import com.chat.chingudachi.domain.auth.AuthToken
 import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
 import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
@@ -19,6 +20,7 @@ class AccountStoreAdapter(
 ) : AccountStore {
     override fun save(account: Account): Account = accountRepository.save(account)
     override fun findById(id: Long): Account? = accountRepository.findByIdOrNull(id)
+    override fun existsByNickname(nickname: String): Boolean = accountRepository.existsByNickname(Nickname(nickname))
 }
 
 @Repository

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/PersistenceAdapters.kt
@@ -20,7 +20,7 @@ class AccountStoreAdapter(
 ) : AccountStore {
     override fun save(account: Account): Account = accountRepository.save(account)
     override fun findById(id: Long): Account? = accountRepository.findByIdOrNull(id)
-    override fun existsByNickname(nickname: String): Boolean = accountRepository.existsByNickname(Nickname(nickname))
+    override fun existsByNickname(nickname: Nickname): Boolean = accountRepository.existsByNickname(nickname)
 }
 
 @Repository

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/account/AccountRepository.kt
@@ -1,6 +1,9 @@
 package com.chat.chingudachi.infrastructure.persistence.account
 
 import com.chat.chingudachi.domain.account.Account
+import com.chat.chingudachi.domain.account.Nickname
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface AccountRepository : JpaRepository<Account, Long>
+interface AccountRepository : JpaRepository<Account, Long> {
+    fun existsByNickname(nickname: Nickname): Boolean
+}

--- a/src/main/kotlin/com/chat/chingudachi/presentation/user/UserController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/user/UserController.kt
@@ -1,10 +1,12 @@
 package com.chat.chingudachi.presentation.user
 
+import com.chat.chingudachi.application.user.CheckNicknameUseCase
 import com.chat.chingudachi.application.user.GetMyProfileUseCase
 import com.chat.chingudachi.application.user.MyProfile
 import com.chat.chingudachi.presentation.common.AuthAccountId
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 
@@ -12,11 +14,18 @@ import java.time.LocalDate
 @RequestMapping("/api/users")
 class UserController(
     private val getMyProfileUseCase: GetMyProfileUseCase,
+    private val checkNicknameUseCase: CheckNicknameUseCase,
 ) {
     @GetMapping("/me")
     fun getMyProfile(@AuthAccountId accountId: Long): MyProfileResponse {
         val profile = getMyProfileUseCase.execute(accountId)
         return MyProfileResponse.from(profile)
+    }
+
+    @GetMapping("/check-nickname")
+    fun checkNickname(@RequestParam nickname: String): NicknameCheckResponse {
+        val available = checkNicknameUseCase.execute(nickname)
+        return NicknameCheckResponse(available)
     }
 }
 
@@ -60,4 +69,8 @@ data class InterestResponse(
     val tagKey: String,
     val labelKo: String,
     val labelJa: String,
+)
+
+data class NicknameCheckResponse(
+    val available: Boolean,
 )

--- a/src/test/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCaseTest.kt
@@ -1,6 +1,8 @@
 package com.chat.chingudachi.application.user
 
 import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.domain.account.Nickname
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
@@ -17,7 +19,7 @@ class CheckNicknameUseCaseTest : DescribeSpec() {
         describe("execute") {
             context("사용 가능한 닉네임") {
                 it("true를 반환한다") {
-                    every { accountStore.existsByNickname("새닉네임") } returns false
+                    every { accountStore.existsByNickname(Nickname("새닉네임")) } returns false
 
                     useCase.execute("새닉네임") shouldBe true
                 }
@@ -25,9 +27,35 @@ class CheckNicknameUseCaseTest : DescribeSpec() {
 
             context("이미 사용 중인 닉네임") {
                 it("false를 반환한다") {
-                    every { accountStore.existsByNickname("중복닉네임") } returns true
+                    every { accountStore.existsByNickname(Nickname("중복닉네임")) } returns true
 
                     useCase.execute("중복닉네임") shouldBe false
+                }
+            }
+
+            context("유효하지 않은 닉네임") {
+                it("빈 문자열이면 IllegalArgumentException을 던진다") {
+                    shouldThrow<IllegalArgumentException> {
+                        useCase.execute("")
+                    }
+                }
+
+                it("1글자이면 IllegalArgumentException을 던진다") {
+                    shouldThrow<IllegalArgumentException> {
+                        useCase.execute("아")
+                    }
+                }
+
+                it("13자 이상이면 IllegalArgumentException을 던진다") {
+                    shouldThrow<IllegalArgumentException> {
+                        useCase.execute("일이삼사오육칠팔구십일이삼")
+                    }
+                }
+
+                it("공백이 포함되면 IllegalArgumentException을 던진다") {
+                    shouldThrow<IllegalArgumentException> {
+                        useCase.execute("닉 네임")
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/user/CheckNicknameUseCaseTest.kt
@@ -1,0 +1,35 @@
+package com.chat.chingudachi.application.user
+
+import com.chat.chingudachi.application.auth.port.AccountStore
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+
+class CheckNicknameUseCaseTest : DescribeSpec() {
+    private val accountStore = mockk<AccountStore>()
+    private val useCase = CheckNicknameUseCase(accountStore)
+
+    init {
+        afterEach { clearMocks(accountStore) }
+
+        describe("execute") {
+            context("사용 가능한 닉네임") {
+                it("true를 반환한다") {
+                    every { accountStore.existsByNickname("새닉네임") } returns false
+
+                    useCase.execute("새닉네임") shouldBe true
+                }
+            }
+
+            context("이미 사용 중인 닉네임") {
+                it("false를 반환한다") {
+                    every { accountStore.existsByNickname("중복닉네임") } returns true
+
+                    useCase.execute("중복닉네임") shouldBe false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `GET /api/users/check-nickname?nickname=X` 엔드포인트 추가
- 닉네임 중복 여부를 확인하여 `{ available: boolean }` 응답 반환
- nickname 컬럼에 unique 제약조건 추가 (DB 레벨 보장)

## Changes
- `CheckNicknameUseCase` — AccountStore.existsByNickname으로 중복 확인
- `UserController` — check-nickname 엔드포인트 + NicknameCheckResponse DTO
- `Account.kt` — nickname 컬럼 `unique = true`
- `AccountStore/Adapter/Repository` — existsByNickname 포트/어댑터/쿼리
- 유닛 테스트 (사용 가능/중복) + 통합 테스트 (사용 가능/중복/미인증 401)
- API 문서 추가

## Notes
- 프로필 이미지 업로드는 MVP 이후로 미룸 (S3 + 이미지 전략 별도 설계 필요)
- 닉네임 검증은 Nickname value object의 기존 규칙 재활용 (2~12자, 공백 불가)

Closes #9