### PR TITLE
feat(user): 온보딩 완료 엔드포인트

### DIFF
--- a/docs/backend/api/complete-onboarding.md
+++ b/docs/backend/api/complete-onboarding.md
@@ -58,4 +58,5 @@ PUT /api/users/profile
 | 400 | INTEREST_TAG_NOT_FOUND | 존재하지 않는 관심사 태그 ID |
 | 401 | UNAUTHORIZED | JWT 없음 또는 유효하지 않음 |
 | 404 | ACCOUNT_NOT_FOUND | 계정을 찾을 수 없음 |
+| 409 | ACCOUNT_ALREADY_ONBOARDED | 이미 온보딩이 완료된 계정 |
 | 409 | ACCOUNT_NICKNAME_DUPLICATE | 닉네임이 이미 사용 중 |

--- a/docs/backend/api/complete-onboarding.md
+++ b/docs/backend/api/complete-onboarding.md
@@ -1,0 +1,61 @@
+# 온보딩 완료
+
+## 엔드포인트
+PUT /api/users/profile
+
+## 인증
+필요 (JWT Bearer token)
+
+## 요청
+
+### Headers
+| 헤더 | 값 |
+|------|-----|
+| Authorization | Bearer {accessToken} |
+| Content-Type | application/json |
+
+### Body
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| nickname | String | Y | 닉네임 (2~12자, 공백 불가) |
+| birthDate | String | Y | 생년월일 (YYYY-MM-DD) |
+| nation | String | Y | 국적 (KR, JP) |
+| interestTagIds | Long[] | Y | 관심사 태그 ID 목록 (1개 이상) |
+
+### 요청 예시
+```json
+{
+  "nickname": "테스트유저",
+  "birthDate": "2000-01-01",
+  "nation": "KR",
+  "interestTagIds": [1, 3, 5]
+}
+```
+
+## 비즈니스 규칙
+- `nativeLanguage`는 `nation`에서 자동 파생 (KR → KO, JP → JA)
+- 기존 관심사를 전체 삭제 후 새로 저장 (replace 전략)
+- 온보딩 완료 시 accountStatus: NOT_CONSENT → ACTIVE
+
+## 응답
+
+### 성공 (200 OK)
+```json
+{
+  "code": null,
+  "data": null,
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-02T10:00:00Z"
+}
+```
+
+### 에러 케이스
+
+| 상태 | 에러 코드 | 설명 |
+|------|-----------|------|
+| 400 | INTEREST_REQUIRED | 관심사를 1개 이상 선택해야 함 |
+| 400 | INTEREST_TAG_NOT_FOUND | 존재하지 않는 관심사 태그 ID |
+| 401 | UNAUTHORIZED | JWT 없음 또는 유효하지 않음 |
+| 404 | ACCOUNT_NOT_FOUND | 계정을 찾을 수 없음 |
+| 409 | ACCOUNT_NICKNAME_DUPLICATE | 닉네임이 이미 사용 중 |

--- a/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
@@ -1,0 +1,57 @@
+package com.chat.chingudachi.application.user
+
+import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.user.port.UserInterestStore
+import com.chat.chingudachi.domain.account.Nation
+import com.chat.chingudachi.domain.account.Nickname
+import com.chat.chingudachi.domain.common.BadRequestException
+import com.chat.chingudachi.domain.common.ConflictException
+import com.chat.chingudachi.domain.common.ErrorCode
+import com.chat.chingudachi.domain.common.NotFoundException
+import com.chat.chingudachi.domain.interest.UserInterest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+data class CompleteOnboardingCommand(
+    val nickname: String,
+    val birthDate: LocalDate,
+    val nation: Nation,
+    val interestTagIds: List<Long>,
+)
+
+@Service
+class CompleteOnboardingUseCase(
+    private val accountStore: AccountStore,
+    private val interestTagStore: InterestTagStore,
+    private val userInterestStore: UserInterestStore,
+) {
+    @Transactional
+    fun execute(accountId: Long, command: CompleteOnboardingCommand) {
+        val account = accountStore.findById(accountId)
+            ?: throw NotFoundException(ErrorCode.ACCOUNT_NOT_FOUND)
+
+        val nickname = Nickname(command.nickname)
+
+        if (accountStore.existsByNickname(nickname)) {
+            throw ConflictException(ErrorCode.ACCOUNT_NICKNAME_DUPLICATE)
+        }
+
+        if (command.interestTagIds.isEmpty()) {
+            throw BadRequestException(ErrorCode.INTEREST_REQUIRED)
+        }
+
+        val interestTags = interestTagStore.findAllByIds(command.interestTagIds)
+        if (interestTags.size != command.interestTagIds.size) {
+            throw BadRequestException(ErrorCode.INTEREST_TAG_NOT_FOUND)
+        }
+
+        account.completeOnboarding(nickname, command.birthDate, command.nation)
+        accountStore.save(account)
+
+        userInterestStore.deleteByAccountId(accountId)
+        val userInterests = interestTags.map { tag -> UserInterest(account = account, interestTag = tag) }
+        userInterestStore.saveAll(userInterests)
+    }
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
@@ -3,6 +3,7 @@ package com.chat.chingudachi.application.user
 import com.chat.chingudachi.application.auth.port.AccountStore
 import com.chat.chingudachi.application.user.port.InterestTagStore
 import com.chat.chingudachi.application.user.port.UserInterestStore
+import com.chat.chingudachi.domain.account.AccountStatus
 import com.chat.chingudachi.domain.account.Nation
 import com.chat.chingudachi.domain.account.Nickname
 import com.chat.chingudachi.domain.common.BadRequestException
@@ -10,9 +11,12 @@ import com.chat.chingudachi.domain.common.ConflictException
 import com.chat.chingudachi.domain.common.ErrorCode
 import com.chat.chingudachi.domain.common.NotFoundException
 import com.chat.chingudachi.domain.interest.UserInterest
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+
+private val log = KotlinLogging.logger {}
 
 data class CompleteOnboardingCommand(
     val nickname: String,
@@ -32,18 +36,24 @@ class CompleteOnboardingUseCase(
         val account = accountStore.findById(accountId)
             ?: throw NotFoundException(ErrorCode.ACCOUNT_NOT_FOUND)
 
+        if (account.accountStatus != AccountStatus.NOT_CONSENT) {
+            throw ConflictException(ErrorCode.ACCOUNT_ALREADY_ONBOARDED)
+        }
+
         val nickname = Nickname(command.nickname)
 
         if (accountStore.existsByNickname(nickname)) {
             throw ConflictException(ErrorCode.ACCOUNT_NICKNAME_DUPLICATE)
         }
 
-        if (command.interestTagIds.isEmpty()) {
+        val distinctTagIds = command.interestTagIds.distinct()
+
+        if (distinctTagIds.isEmpty()) {
             throw BadRequestException(ErrorCode.INTEREST_REQUIRED)
         }
 
-        val interestTags = interestTagStore.findAllByIds(command.interestTagIds)
-        if (interestTags.size != command.interestTagIds.size) {
+        val interestTags = interestTagStore.findAllByIds(distinctTagIds)
+        if (interestTags.size != distinctTagIds.size) {
             throw BadRequestException(ErrorCode.INTEREST_TAG_NOT_FOUND)
         }
 
@@ -53,5 +63,7 @@ class CompleteOnboardingUseCase(
         userInterestStore.deleteByAccountId(accountId)
         val userInterests = interestTags.map { tag -> UserInterest(account = account, interestTag = tag) }
         userInterestStore.saveAll(userInterests)
+
+        log.info { "Onboarding completed: accountId=$accountId, nickname=${nickname.value}, nation=${command.nation}" }
     }
 }

--- a/src/main/kotlin/com/chat/chingudachi/application/user/port/InterestTagStore.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/port/InterestTagStore.kt
@@ -1,0 +1,7 @@
+package com.chat.chingudachi.application.user.port
+
+import com.chat.chingudachi.domain.interest.InterestTag
+
+interface InterestTagStore {
+    fun findAllByIds(ids: List<Long>): List<InterestTag>
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/user/port/UserInterestStore.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/port/UserInterestStore.kt
@@ -4,4 +4,6 @@ import com.chat.chingudachi.domain.interest.UserInterest
 
 interface UserInterestStore {
     fun findByAccountId(accountId: Long): List<UserInterest>
+    fun saveAll(userInterests: List<UserInterest>): List<UserInterest>
+    fun deleteByAccountId(accountId: Long)
 }

--- a/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/account/Account.kt
@@ -50,6 +50,14 @@ class Account(
             birthDate != null &&
             nation != null &&
             nativeLanguage != null
+
+    fun completeOnboarding(nickname: Nickname, birthDate: LocalDate, nation: Nation) {
+        this.nickname = nickname
+        this.birthDate = birthDate
+        this.nation = nation
+        this.nativeLanguage = nation.toNativeLanguage()
+        this.accountStatus = AccountStatus.ACTIVE
+    }
 }
 
 @JvmInline

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -21,6 +21,7 @@ enum class ErrorCode(
     ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "Account already exists"),
     ACCOUNT_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "Nickname must be 2-12 characters without spaces"),
     ACCOUNT_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "Nickname is already taken"),
+    ACCOUNT_ALREADY_ONBOARDED(HttpStatus.CONFLICT, "Onboarding is already completed"),
 
     // Interest
     INTEREST_TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "One or more interest tags not found"),

--- a/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
+++ b/src/main/kotlin/com/chat/chingudachi/domain/common/ErrorCode.kt
@@ -20,6 +20,11 @@ enum class ErrorCode(
     ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "Account not found"),
     ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "Account already exists"),
     ACCOUNT_NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "Nickname must be 2-12 characters without spaces"),
+    ACCOUNT_NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "Nickname is already taken"),
+
+    // Interest
+    INTEREST_TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "One or more interest tags not found"),
+    INTEREST_REQUIRED(HttpStatus.BAD_REQUEST, "At least one interest is required"),
 
     // Auth
     AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "Token has expired"),

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
@@ -1,0 +1,13 @@
+package com.chat.chingudachi.infrastructure.persistence.interest
+
+import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.domain.interest.InterestTag
+import org.springframework.stereotype.Repository
+
+@Repository
+class InterestTagStoreAdapter(
+    private val interestTagRepository: InterestTagRepository,
+) : InterestTagStore {
+    override fun findAllByIds(ids: List<Long>): List<InterestTag> =
+        interestTagRepository.findAllById(ids)
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface UserInterestRepository : JpaRepository<UserInterest, Long> {
     @EntityGraph(attributePaths = ["interestTag"])
     fun findByAccountId(accountId: Long): List<UserInterest>
+    fun deleteByAccountId(accountId: Long)
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestStoreAdapter.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/UserInterestStoreAdapter.kt
@@ -10,4 +10,10 @@ class UserInterestStoreAdapter(
 ) : UserInterestStore {
     override fun findByAccountId(accountId: Long): List<UserInterest> =
         userInterestRepository.findByAccountId(accountId)
+
+    override fun saveAll(userInterests: List<UserInterest>): List<UserInterest> =
+        userInterestRepository.saveAll(userInterests)
+
+    override fun deleteByAccountId(accountId: Long) =
+        userInterestRepository.deleteByAccountId(accountId)
 }

--- a/src/main/kotlin/com/chat/chingudachi/presentation/user/UserController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/user/UserController.kt
@@ -1,10 +1,15 @@
 package com.chat.chingudachi.presentation.user
 
 import com.chat.chingudachi.application.user.CheckNicknameUseCase
+import com.chat.chingudachi.application.user.CompleteOnboardingCommand
+import com.chat.chingudachi.application.user.CompleteOnboardingUseCase
 import com.chat.chingudachi.application.user.GetMyProfileUseCase
 import com.chat.chingudachi.application.user.MyProfile
+import com.chat.chingudachi.domain.account.Nation
 import com.chat.chingudachi.presentation.common.AuthAccountId
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -15,6 +20,7 @@ import java.time.LocalDate
 class UserController(
     private val getMyProfileUseCase: GetMyProfileUseCase,
     private val checkNicknameUseCase: CheckNicknameUseCase,
+    private val completeOnboardingUseCase: CompleteOnboardingUseCase,
 ) {
     @GetMapping("/me")
     fun getMyProfile(@AuthAccountId accountId: Long): MyProfileResponse {
@@ -26,6 +32,14 @@ class UserController(
     fun checkNickname(@RequestParam nickname: String): NicknameCheckResponse {
         val available = checkNicknameUseCase.execute(nickname)
         return NicknameCheckResponse(available)
+    }
+
+    @PutMapping("/profile")
+    fun completeOnboarding(
+        @AuthAccountId accountId: Long,
+        @RequestBody request: CompleteOnboardingRequest,
+    ) {
+        completeOnboardingUseCase.execute(accountId, request.toCommand())
     }
 }
 
@@ -74,3 +88,17 @@ data class InterestResponse(
 data class NicknameCheckResponse(
     val available: Boolean,
 )
+
+data class CompleteOnboardingRequest(
+    val nickname: String,
+    val birthDate: LocalDate,
+    val nation: Nation,
+    val interestTagIds: List<Long>,
+) {
+    fun toCommand() = CompleteOnboardingCommand(
+        nickname = nickname,
+        birthDate = birthDate,
+        nation = nation,
+        interestTagIds = interestTagIds,
+    )
+}

--- a/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
@@ -73,6 +73,17 @@ class CompleteOnboardingUseCaseTest : DescribeSpec() {
                 }
             }
 
+            context("이미 온보딩 완료된 계정") {
+                it("ConflictException을 던진다") {
+                    val account = AccountFixture.create(id = 1, accountStatus = AccountStatus.ACTIVE)
+                    every { accountStore.findById(1L) } returns account
+
+                    shouldThrow<ConflictException> {
+                        useCase.execute(1L, validCommand)
+                    }
+                }
+            }
+
             context("중복 닉네임") {
                 it("ConflictException을 던진다") {
                     val account = AccountFixture.create(id = 1)

--- a/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
@@ -1,0 +1,118 @@
+package com.chat.chingudachi.application.user
+
+import com.chat.chingudachi.application.auth.port.AccountStore
+import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.user.port.UserInterestStore
+import com.chat.chingudachi.domain.account.AccountStatus
+import com.chat.chingudachi.domain.account.Nation
+import com.chat.chingudachi.domain.account.Nickname
+import com.chat.chingudachi.domain.common.BadRequestException
+import com.chat.chingudachi.domain.common.ConflictException
+import com.chat.chingudachi.domain.common.NotFoundException
+import com.chat.chingudachi.domain.interest.InterestTag
+import com.chat.chingudachi.domain.interest.UserInterest
+import com.chat.chingudachi.fixture.AccountFixture
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.time.LocalDate
+
+class CompleteOnboardingUseCaseTest : DescribeSpec() {
+    private val accountStore = mockk<AccountStore>(relaxed = true)
+    private val interestTagStore = mockk<InterestTagStore>()
+    private val userInterestStore = mockk<UserInterestStore>(relaxed = true)
+    private val useCase = CompleteOnboardingUseCase(accountStore, interestTagStore, userInterestStore)
+
+    private val validCommand = CompleteOnboardingCommand(
+        nickname = "테스트닉네임",
+        birthDate = LocalDate.of(2000, 1, 1),
+        nation = Nation.KR,
+        interestTagIds = listOf(1L, 2L),
+    )
+
+    private val testTags = listOf(
+        InterestTag(id = 1, tagKey = "TRAVEL", labelKo = "여행", labelJa = "旅行", displayOrder = 1),
+        InterestTag(id = 2, tagKey = "FOOD", labelKo = "음식", labelJa = "食べ物", displayOrder = 2),
+    )
+
+    init {
+        afterEach { clearMocks(accountStore, interestTagStore, userInterestStore) }
+
+        describe("execute") {
+            context("유효한 온보딩 데이터") {
+                it("계정 상태를 ACTIVE로 변경하고 관심사를 저장한다") {
+                    val account = AccountFixture.create(id = 1)
+                    every { accountStore.findById(1L) } returns account
+                    every { accountStore.existsByNickname(Nickname("테스트닉네임")) } returns false
+                    every { interestTagStore.findAllByIds(listOf(1L, 2L)) } returns testTags
+
+                    useCase.execute(1L, validCommand)
+
+                    account.accountStatus shouldBe AccountStatus.ACTIVE
+                    account.nickname shouldBe Nickname("테스트닉네임")
+                    account.nation shouldBe Nation.KR
+                    account.nativeLanguage shouldBe com.chat.chingudachi.domain.account.NativeLanguage.KO
+                    verify { accountStore.save(account) }
+                    verify { userInterestStore.deleteByAccountId(1L) }
+                    verify { userInterestStore.saveAll(match<List<UserInterest>> { it.size == 2 }) }
+                }
+            }
+
+            context("존재하지 않는 계정") {
+                it("NotFoundException을 던진다") {
+                    every { accountStore.findById(999L) } returns null
+
+                    shouldThrow<NotFoundException> {
+                        useCase.execute(999L, validCommand)
+                    }
+                }
+            }
+
+            context("중복 닉네임") {
+                it("ConflictException을 던진다") {
+                    val account = AccountFixture.create(id = 1)
+                    every { accountStore.findById(1L) } returns account
+                    every { accountStore.existsByNickname(Nickname("테스트닉네임")) } returns true
+
+                    shouldThrow<ConflictException> {
+                        useCase.execute(1L, validCommand)
+                    }
+                }
+            }
+
+            context("관심사 미선택") {
+                it("BadRequestException을 던진다") {
+                    val account = AccountFixture.create(id = 1)
+                    every { accountStore.findById(1L) } returns account
+                    every { accountStore.existsByNickname(Nickname("테스트닉네임")) } returns false
+
+                    val emptyInterests = validCommand.copy(interestTagIds = emptyList())
+
+                    shouldThrow<BadRequestException> {
+                        useCase.execute(1L, emptyInterests)
+                    }
+                }
+            }
+
+            context("존재하지 않는 관심사 태그 ID") {
+                it("BadRequestException을 던진다") {
+                    val account = AccountFixture.create(id = 1)
+                    every { accountStore.findById(1L) } returns account
+                    every { accountStore.existsByNickname(Nickname("테스트닉네임")) } returns false
+                    every { interestTagStore.findAllByIds(listOf(1L, 999L)) } returns listOf(testTags[0])
+
+                    val invalidTags = validCommand.copy(interestTagIds = listOf(1L, 999L))
+
+                    shouldThrow<BadRequestException> {
+                        useCase.execute(1L, invalidTags)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/presentation/user/OnboardingIntegrationTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/presentation/user/OnboardingIntegrationTest.kt
@@ -1,0 +1,194 @@
+package com.chat.chingudachi.presentation.user
+
+import com.chat.chingudachi.application.auth.port.OAuthClient
+import com.chat.chingudachi.domain.account.Nickname
+import com.chat.chingudachi.domain.auth.OAuthProvider
+import com.chat.chingudachi.domain.auth.OAuthUserInfo
+import com.chat.chingudachi.domain.interest.InterestTag
+import com.chat.chingudachi.fixture.AccountFixture
+import com.chat.chingudachi.infrastructure.persistence.account.AccountCredentialRepository
+import com.chat.chingudachi.infrastructure.persistence.account.AccountRepository
+import com.chat.chingudachi.infrastructure.persistence.auth.AuthTokenRepository
+import com.chat.chingudachi.infrastructure.persistence.interest.InterestTagRepository
+import com.chat.chingudachi.infrastructure.persistence.interest.UserInterestRepository
+import com.chat.chingudachi.support.MockOAuthConfig
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.clearMocks
+import io.mockk.every
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureEmbeddedDatabase
+@Import(MockOAuthConfig::class)
+class OnboardingIntegrationTest(
+    private val mockMvc: MockMvc,
+    private val oAuthClient: OAuthClient,
+    private val authTokenRepository: AuthTokenRepository,
+    private val accountCredentialRepository: AccountCredentialRepository,
+    private val accountRepository: AccountRepository,
+    private val interestTagRepository: InterestTagRepository,
+    private val userInterestRepository: UserInterestRepository,
+) : DescribeSpec() {
+
+    private fun loginAndGetToken(oauthKey: String = "google-300", email: String = "onboard@example.com"): String {
+        every { oAuthClient.authenticate("valid-code") } returns
+            OAuthUserInfo(OAuthProvider.GOOGLE, oauthKey, email)
+
+        val result = mockMvc.post("/api/auth/google") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"code":"valid-code"}"""
+        }.andReturn()
+
+        return com.jayway.jsonpath.JsonPath.read(
+            result.response.contentAsString,
+            "$.data.accessToken",
+        )
+    }
+
+    private fun seedInterestTags(): List<InterestTag> =
+        interestTagRepository.saveAll(
+            listOf(
+                InterestTag(tagKey = "TRAVEL", labelKo = "여행", labelJa = "旅行", displayOrder = 1),
+                InterestTag(tagKey = "FOOD", labelKo = "음식", labelJa = "食べ物", displayOrder = 2),
+                InterestTag(tagKey = "MUSIC", labelKo = "음악", labelJa = "音楽", displayOrder = 3),
+            ),
+        )
+
+    init {
+        afterEach {
+            clearMocks(oAuthClient)
+            userInterestRepository.deleteAll()
+            authTokenRepository.deleteAll()
+            accountCredentialRepository.deleteAll()
+            accountRepository.deleteAll()
+            interestTagRepository.deleteAll()
+        }
+
+        describe("PUT /api/users/profile") {
+            context("유효한 온보딩 데이터") {
+                it("계정 상태를 ACTIVE로 변경한다") {
+                    val token = loginAndGetToken()
+                    val tags = seedInterestTags()
+
+                    mockMvc.put("/api/users/profile") {
+                        header("Authorization", "Bearer $token")
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """
+                            {
+                                "nickname": "테스트유저",
+                                "birthDate": "2000-01-01",
+                                "nation": "KR",
+                                "interestTagIds": [${tags[0].id}, ${tags[1].id}]
+                            }
+                        """.trimIndent()
+                    }.andExpect {
+                        status { isOk() }
+                    }
+
+                    mockMvc.get("/api/users/me") {
+                        header("Authorization", "Bearer $token")
+                    }.andExpect {
+                        status { isOk() }
+                        jsonPath("$.data.accountStatus") { value("ACTIVE") }
+                        jsonPath("$.data.nickname") { value("테스트유저") }
+                        jsonPath("$.data.nation") { value("KR") }
+                        jsonPath("$.data.nativeLanguage") { value("KO") }
+                        jsonPath("$.data.interests") { isArray() }
+                    }
+                }
+            }
+
+            context("닉네임이 중복되면") {
+                it("409를 반환한다") {
+                    val token = loginAndGetToken()
+                    val tags = seedInterestTags()
+                    accountRepository.save(AccountFixture.create(id = 0, nickname = Nickname("중복닉네임")))
+
+                    mockMvc.put("/api/users/profile") {
+                        header("Authorization", "Bearer $token")
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """
+                            {
+                                "nickname": "중복닉네임",
+                                "birthDate": "2000-01-01",
+                                "nation": "KR",
+                                "interestTagIds": [${tags[0].id}]
+                            }
+                        """.trimIndent()
+                    }.andExpect {
+                        status { isConflict() }
+                    }
+                }
+            }
+
+            context("관심사를 선택하지 않으면") {
+                it("400을 반환한다") {
+                    val token = loginAndGetToken()
+
+                    mockMvc.put("/api/users/profile") {
+                        header("Authorization", "Bearer $token")
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """
+                            {
+                                "nickname": "테스트유저",
+                                "birthDate": "2000-01-01",
+                                "nation": "KR",
+                                "interestTagIds": []
+                            }
+                        """.trimIndent()
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }
+                }
+            }
+
+            context("존재하지 않는 관심사 태그 ID") {
+                it("400을 반환한다") {
+                    val token = loginAndGetToken()
+
+                    mockMvc.put("/api/users/profile") {
+                        header("Authorization", "Bearer $token")
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """
+                            {
+                                "nickname": "테스트유저",
+                                "birthDate": "2000-01-01",
+                                "nation": "KR",
+                                "interestTagIds": [9999]
+                            }
+                        """.trimIndent()
+                    }.andExpect {
+                        status { isBadRequest() }
+                    }
+                }
+            }
+
+            context("인증 없이 요청하면") {
+                it("401을 반환한다") {
+                    mockMvc.put("/api/users/profile") {
+                        contentType = MediaType.APPLICATION_JSON
+                        content = """
+                            {
+                                "nickname": "테스트유저",
+                                "birthDate": "2000-01-01",
+                                "nation": "KR",
+                                "interestTagIds": [1]
+                            }
+                        """.trimIndent()
+                    }.andExpect {
+                        status { isUnauthorized() }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `PUT /api/users/profile` 온보딩 완료 엔드포인트 추가
- 닉네임/생년월일/국적/관심사를 저장하고 계정 상태를 ACTIVE로 전이
- nativeLanguage는 nation에서 자동 파생 (KR→KO, JP→JA)

## Changes
- `Account.completeOnboarding()` — 도메인 메서드로 상태 전이 캡슐화
- `CompleteOnboardingUseCase` — 닉네임 중복 검증 + 관심사 유효성 확인 + 저장
- `InterestTagStore` port + adapter — 관심사 태그 조회
- `UserInterestStore` 확장 — saveAll, deleteByAccountId (replace 전략)
- `UserController` — PUT /api/users/profile 엔드포인트 + Request DTO
- ErrorCode 3개 추가 (ACCOUNT_NICKNAME_DUPLICATE, INTEREST_REQUIRED, INTEREST_TAG_NOT_FOUND)
- 유닛 테스트 5케이스 + 통합 테스트 5케이스
- API 문서 추가

## Notes
- 기존 관심사는 전체 삭제 후 새로 저장 (replace 전략)
- 닉네임 중복 시 409, 관심사 미선택/잘못된 태그 시 400

Closes #10