### PR TITLE
[BE-10] 관심사 태그 목록 API

### DIFF
--- a/docs/backend/api/interest-tags.md
+++ b/docs/backend/api/interest-tags.md
@@ -1,0 +1,48 @@
+# 관심사 태그 목록 조회
+
+## 엔드포인트
+GET /api/interest-tags
+
+## 인증
+불필요 (permitAll)
+
+## 요청
+파라미터 없음
+
+## 비즈니스 규칙
+- `displayOrder` 기준 오름차순 정렬
+- 정적 데이터이므로 HTTP Cache-Control 적용 (max-age=3600, public)
+- 온보딩 화면에서 관심사 선택 시 사용
+
+## 응답
+
+### 성공 (200 OK)
+```json
+{
+  "code": null,
+  "data": [
+    {
+      "id": 1,
+      "tagKey": "TRAVEL",
+      "labelKo": "여행",
+      "labelJa": "旅行",
+      "displayOrder": 1
+    },
+    {
+      "id": 2,
+      "tagKey": "FOOD",
+      "labelKo": "음식",
+      "labelJa": "食べ物",
+      "displayOrder": 2
+    }
+  ],
+  "message": "success",
+  "isSuccess": true,
+  "timestamp": "2026-03-02T10:00:00Z"
+}
+```
+
+### 응답 헤더
+| 헤더 | 값 |
+|------|------|
+| Cache-Control | max-age=3600, public |

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthConstants.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthConstants.kt
@@ -1,7 +1,0 @@
-package com.chat.chingudachi.application.auth
-
-import java.time.Duration
-
-object AuthConstants {
-    val REFRESH_TOKEN_TTL: Duration = Duration.ofDays(30)
-}

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCase.kt
@@ -73,7 +73,7 @@ class AuthenticateUseCase(
             AuthToken(
                 account = account,
                 refreshToken = refreshToken,
-                expiresAt = Instant.now().plus(AuthConstants.REFRESH_TOKEN_TTL),
+                expiresAt = Instant.now().plus(tokenProvider.refreshTokenExpiry),
             ),
         )
 

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCase.kt
@@ -39,7 +39,7 @@ class RefreshTokenUseCase(
             AuthToken(
                 account = account,
                 refreshToken = newRefreshToken,
-                expiresAt = Instant.now().plus(AuthConstants.REFRESH_TOKEN_TTL),
+                expiresAt = Instant.now().plus(tokenProvider.refreshTokenExpiry),
             ),
         )
 

--- a/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/auth/port/TokenProvider.kt
@@ -1,8 +1,11 @@
 package com.chat.chingudachi.application.auth.port
 
+import java.time.Duration
+
 interface TokenProvider {
     fun createAccessToken(accountId: Long): String
     fun createRefreshToken(accountId: Long): String
     fun validateToken(token: String): Boolean
     fun parseAccountId(token: String): Long
+    val refreshTokenExpiry: Duration
 }

--- a/src/main/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCase.kt
@@ -1,0 +1,14 @@
+package com.chat.chingudachi.application.interest
+
+import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.domain.interest.InterestTag
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetInterestTagsUseCase(
+    private val interestTagStore: InterestTagStore,
+) {
+    @Transactional(readOnly = true)
+    fun execute(): List<InterestTag> = interestTagStore.findAllOrderByDisplayOrder()
+}

--- a/src/main/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCase.kt
@@ -1,6 +1,6 @@
 package com.chat.chingudachi.application.interest
 
-import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.interest.port.InterestTagStore
 import com.chat.chingudachi.domain.interest.InterestTag
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/src/main/kotlin/com/chat/chingudachi/application/interest/port/InterestTagStore.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/interest/port/InterestTagStore.kt
@@ -1,4 +1,4 @@
-package com.chat.chingudachi.application.user.port
+package com.chat.chingudachi.application.interest.port
 
 import com.chat.chingudachi.domain.interest.InterestTag
 

--- a/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCase.kt
@@ -1,7 +1,7 @@
 package com.chat.chingudachi.application.user
 
 import com.chat.chingudachi.application.auth.port.AccountStore
-import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.interest.port.InterestTagStore
 import com.chat.chingudachi.application.user.port.UserInterestStore
 import com.chat.chingudachi.domain.account.AccountStatus
 import com.chat.chingudachi.domain.account.Nation

--- a/src/main/kotlin/com/chat/chingudachi/application/user/port/InterestTagStore.kt
+++ b/src/main/kotlin/com/chat/chingudachi/application/user/port/InterestTagStore.kt
@@ -4,4 +4,5 @@ import com.chat.chingudachi.domain.interest.InterestTag
 
 interface InterestTagStore {
     fun findAllByIds(ids: List<Long>): List<InterestTag>
+    fun findAllOrderByDisplayOrder(): List<InterestTag>
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
@@ -37,6 +37,7 @@ class SecurityConfig(
             }
             authorizeHttpRequests {
                 authorize("/api/auth/**", permitAll)
+                authorize("/api/interest-tags", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/config/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.annotation.web.invoke
@@ -37,7 +38,7 @@ class SecurityConfig(
             }
             authorizeHttpRequests {
                 authorize("/api/auth/**", permitAll)
-                authorize("/api/interest-tags", permitAll)
+                authorize(HttpMethod.GET, "/api/interest-tags", permitAll)
                 authorize(anyRequest, authenticated)
             }
             exceptionHandling {

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/jwt/JwtProvider.kt
@@ -9,6 +9,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Component
+import java.time.Duration
 import java.util.Date
 import javax.crypto.SecretKey
 
@@ -19,6 +20,9 @@ class JwtProvider(
     private val secretKey: SecretKey = Keys.hmacShaKeyFor(
         Decoders.BASE64.decode(jwtProperties.secret),
     )
+
+    override val refreshTokenExpiry: Duration
+        get() = jwtProperties.refreshTokenExpiry
 
     override fun createAccessToken(accountId: Long): String =
         createToken(accountId, jwtProperties.accessTokenExpiry.toMillis())

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagRepository.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagRepository.kt
@@ -3,4 +3,6 @@ package com.chat.chingudachi.infrastructure.persistence.interest
 import com.chat.chingudachi.domain.interest.InterestTag
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface InterestTagRepository : JpaRepository<InterestTag, Long>
+interface InterestTagRepository : JpaRepository<InterestTag, Long> {
+    fun findAllByOrderByDisplayOrderAsc(): List<InterestTag>
+}

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
@@ -10,4 +10,7 @@ class InterestTagStoreAdapter(
 ) : InterestTagStore {
     override fun findAllByIds(ids: List<Long>): List<InterestTag> =
         interestTagRepository.findAllById(ids)
+
+    override fun findAllOrderByDisplayOrder(): List<InterestTag> =
+        interestTagRepository.findAllByOrderByDisplayOrderAsc()
 }

--- a/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
+++ b/src/main/kotlin/com/chat/chingudachi/infrastructure/persistence/interest/InterestTagStoreAdapter.kt
@@ -1,6 +1,6 @@
 package com.chat.chingudachi.infrastructure.persistence.interest
 
-import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.interest.port.InterestTagStore
 import com.chat.chingudachi.domain.interest.InterestTag
 import org.springframework.stereotype.Repository
 

--- a/src/main/kotlin/com/chat/chingudachi/presentation/auth/AuthController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/auth/AuthController.kt
@@ -1,8 +1,8 @@
 package com.chat.chingudachi.presentation.auth
 
-import com.chat.chingudachi.application.auth.AuthConstants
 import com.chat.chingudachi.application.auth.AuthenticateUseCase
 import com.chat.chingudachi.application.auth.RefreshTokenUseCase
+import com.chat.chingudachi.application.auth.port.TokenProvider
 import com.chat.chingudachi.application.auth.command.AuthenticateCommand
 import com.chat.chingudachi.domain.common.ErrorCode
 import com.chat.chingudachi.domain.common.UnauthorizedException
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val authenticateUseCase: AuthenticateUseCase,
     private val refreshTokenUseCase: RefreshTokenUseCase,
+    private val tokenProvider: TokenProvider,
 ) {
     @PostMapping("/google")
     fun googleLogin(
@@ -55,7 +56,7 @@ class AuthController(
             .secure(true)
             .sameSite("Lax")
             .path("/api/auth/refresh")
-            .maxAge(AuthConstants.REFRESH_TOKEN_TTL)
+            .maxAge(tokenProvider.refreshTokenExpiry)
             .build()
         response.addHeader("Set-Cookie", cookie.toString())
     }

--- a/src/main/kotlin/com/chat/chingudachi/presentation/interest/InterestTagController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/interest/InterestTagController.kt
@@ -1,6 +1,7 @@
 package com.chat.chingudachi.presentation.interest
 
 import com.chat.chingudachi.application.interest.GetInterestTagsUseCase
+import com.chat.chingudachi.domain.interest.InterestTag
 import org.springframework.http.CacheControl
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -31,7 +32,7 @@ data class InterestTagResponse(
     val displayOrder: Int,
 ) {
     companion object {
-        fun from(tag: com.chat.chingudachi.domain.interest.InterestTag) = InterestTagResponse(
+        fun from(tag: InterestTag) = InterestTagResponse(
             id = tag.id,
             tagKey = tag.tagKey,
             labelKo = tag.labelKo,

--- a/src/main/kotlin/com/chat/chingudachi/presentation/interest/InterestTagController.kt
+++ b/src/main/kotlin/com/chat/chingudachi/presentation/interest/InterestTagController.kt
@@ -1,0 +1,42 @@
+package com.chat.chingudachi.presentation.interest
+
+import com.chat.chingudachi.application.interest.GetInterestTagsUseCase
+import org.springframework.http.CacheControl
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.concurrent.TimeUnit
+
+@RestController
+@RequestMapping("/api/interest-tags")
+class InterestTagController(
+    private val getInterestTagsUseCase: GetInterestTagsUseCase,
+) {
+    @GetMapping
+    fun getInterestTags(): ResponseEntity<List<InterestTagResponse>> {
+        val tags = getInterestTagsUseCase.execute()
+        val response = tags.map { InterestTagResponse.from(it) }
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic())
+            .body(response)
+    }
+}
+
+data class InterestTagResponse(
+    val id: Long,
+    val tagKey: String,
+    val labelKo: String,
+    val labelJa: String,
+    val displayOrder: Int,
+) {
+    companion object {
+        fun from(tag: com.chat.chingudachi.domain.interest.InterestTag) = InterestTagResponse(
+            id = tag.id,
+            tagKey = tag.tagKey,
+            labelKo = tag.labelKo,
+            labelJa = tag.labelJa,
+            displayOrder = tag.displayOrder,
+        )
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/auth/AuthenticateUseCaseTest.kt
@@ -23,6 +23,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import java.time.Duration
 import java.time.LocalDate
 
 class AuthenticateUseCaseTest : DescribeSpec() {
@@ -43,6 +44,7 @@ class AuthenticateUseCaseTest : DescribeSpec() {
     init {
         beforeEach {
             clearMocks(oAuthClient, accountStore, accountCredentialStore, authTokenStore, tokenProvider)
+            every { tokenProvider.refreshTokenExpiry } returns Duration.ofDays(30)
         }
 
         describe("authenticate") {

--- a/src/test/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/auth/RefreshTokenUseCaseTest.kt
@@ -33,6 +33,7 @@ class RefreshTokenUseCaseTest : DescribeSpec() {
     init {
         beforeEach {
             clearMocks(authTokenStore, tokenProvider)
+            every { tokenProvider.refreshTokenExpiry } returns Duration.ofDays(30)
         }
 
         describe("refresh") {

--- a/src/test/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.chat.chingudachi.application.interest
+
+import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.domain.interest.InterestTag
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class GetInterestTagsUseCaseTest : DescribeSpec() {
+    private val interestTagStore = mockk<InterestTagStore>()
+    private val useCase = GetInterestTagsUseCase(interestTagStore)
+
+    init {
+        describe("execute") {
+            context("태그가 존재하면") {
+                it("displayOrder 순으로 반환한다") {
+                    val tags = listOf(
+                        InterestTag(id = 1, tagKey = "TRAVEL", labelKo = "여행", labelJa = "旅行", displayOrder = 1),
+                        InterestTag(id = 2, tagKey = "FOOD", labelKo = "음식", labelJa = "食べ物", displayOrder = 2),
+                        InterestTag(id = 3, tagKey = "MUSIC", labelKo = "음악", labelJa = "音楽", displayOrder = 3),
+                    )
+                    every { interestTagStore.findAllOrderByDisplayOrder() } returns tags
+
+                    val result = useCase.execute()
+
+                    result.size shouldBe 3
+                    result[0].tagKey shouldBe "TRAVEL"
+                    result[1].tagKey shouldBe "FOOD"
+                    result[2].tagKey shouldBe "MUSIC"
+                    verify(exactly = 1) { interestTagStore.findAllOrderByDisplayOrder() }
+                }
+            }
+
+            context("태그가 없으면") {
+                it("빈 리스트를 반환한다") {
+                    every { interestTagStore.findAllOrderByDisplayOrder() } returns emptyList()
+
+                    val result = useCase.execute()
+
+                    result.shouldBeEmpty()
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/interest/GetInterestTagsUseCaseTest.kt
@@ -1,6 +1,6 @@
 package com.chat.chingudachi.application.interest
 
-import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.interest.port.InterestTagStore
 import com.chat.chingudachi.domain.interest.InterestTag
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldBeEmpty

--- a/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/application/user/CompleteOnboardingUseCaseTest.kt
@@ -1,7 +1,7 @@
 package com.chat.chingudachi.application.user
 
 import com.chat.chingudachi.application.auth.port.AccountStore
-import com.chat.chingudachi.application.user.port.InterestTagStore
+import com.chat.chingudachi.application.interest.port.InterestTagStore
 import com.chat.chingudachi.application.user.port.UserInterestStore
 import com.chat.chingudachi.domain.account.AccountStatus
 import com.chat.chingudachi.domain.account.Nation

--- a/src/test/kotlin/com/chat/chingudachi/presentation/interest/InterestTagControllerTest.kt
+++ b/src/test/kotlin/com/chat/chingudachi/presentation/interest/InterestTagControllerTest.kt
@@ -1,0 +1,73 @@
+package com.chat.chingudachi.presentation.interest
+
+import com.chat.chingudachi.domain.interest.InterestTag
+import com.chat.chingudachi.infrastructure.persistence.interest.InterestTagRepository
+import com.chat.chingudachi.support.MockOAuthConfig
+import io.kotest.core.spec.style.DescribeSpec
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureEmbeddedDatabase
+@Import(MockOAuthConfig::class)
+class InterestTagControllerTest(
+    private val mockMvc: MockMvc,
+    private val interestTagRepository: InterestTagRepository,
+) : DescribeSpec() {
+
+    init {
+        afterEach {
+            interestTagRepository.deleteAll()
+        }
+
+        describe("GET /api/interest-tags") {
+            context("태그가 존재하면") {
+                it("displayOrder 순으로 반환한다") {
+                    interestTagRepository.saveAll(
+                        listOf(
+                            InterestTag(tagKey = "MUSIC", labelKo = "음악", labelJa = "音楽", displayOrder = 3),
+                            InterestTag(tagKey = "TRAVEL", labelKo = "여행", labelJa = "旅行", displayOrder = 1),
+                            InterestTag(tagKey = "FOOD", labelKo = "음식", labelJa = "食べ物", displayOrder = 2),
+                        ),
+                    )
+
+                    mockMvc.get("/api/interest-tags")
+                        .andExpect {
+                            status { isOk() }
+                            jsonPath("$.data.length()") { value(3) }
+                            jsonPath("$.data[0].tagKey") { value("TRAVEL") }
+                            jsonPath("$.data[0].displayOrder") { value(1) }
+                            jsonPath("$.data[1].tagKey") { value("FOOD") }
+                            jsonPath("$.data[2].tagKey") { value("MUSIC") }
+                            header { string("Cache-Control", "max-age=3600, public") }
+                        }
+                }
+            }
+
+            context("태그가 없으면") {
+                it("빈 배열을 반환한다") {
+                    mockMvc.get("/api/interest-tags")
+                        .andExpect {
+                            status { isOk() }
+                            jsonPath("$.data") { isArray() }
+                            jsonPath("$.data.length()") { value(0) }
+                        }
+                }
+            }
+
+            context("인증 없이도") {
+                it("접근 가능하다") {
+                    mockMvc.get("/api/interest-tags")
+                        .andExpect {
+                            status { isOk() }
+                        }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
온보딩 화면에서 관심사 선택에 필요한 태그 목록을 조회하는 공개 API 엔드포인트 추가.

## Changes
- `GET /api/interest-tags` 엔드포인트 신규 생성 (permitAll)
- `GetInterestTagsUseCase` — displayOrder 기준 정렬 조회 (readOnly 트랜잭션)
- `InterestTagController` — Cache-Control 헤더 적용 (max-age=3600, public)
- `InterestTagStore` 포트에 `findAllOrderByDisplayOrder()` 추가
- `SecurityConfig`에 `/api/interest-tags` permitAll 등록
- 단위 테스트 2개 + 통합 테스트 3개 (정렬, 빈 배열, 비인증 접근)

## Notes
- 정적 데이터이므로 HTTP 캐시 1시간 설정
- 비인증 접근 허용 (온보딩 중인 유저가 태그 목록을 먼저 조회해야 함)

Closes #11